### PR TITLE
call Translation.Get & GetC directly 

### DIFF
--- a/fixtures/ar/categories.po
+++ b/fixtures/ar/categories.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
 
 msgid "Alcohol & Tobacco"
 msgstr "الكحول والتبغ"

--- a/fixtures/ar/categories.po
+++ b/fixtures/ar/categories.po
@@ -4,3 +4,16 @@ msgstr ""
 
 msgid "Alcohol & Tobacco"
 msgstr "الكحول والتبغ"
+
+# this test data is purposely missing msgstr
+msgid "%d selected"
+msgid_plural "%d selected"
+
+msgid "Load %d more document"
+msgid_plural "Load %d more documents"
+msgstr[0] "حمّل %d مستندات إضافيّة"
+msgstr[1] "حمّل مستند واحد إضافي"
+msgstr[2] "حمّل مستندين إضافيين"
+msgstr[3] "حمّل %d مستندات إضافيّة"
+msgstr[4] "حمّل %d مستندا إضافيّا"
+msgstr[5] "حمّل %d مستند إضافي"

--- a/fixtures/ar/no_plural_header.po
+++ b/fixtures/ar/no_plural_header.po
@@ -1,0 +1,2 @@
+msgid "Alcohol & Tobacco"
+msgstr "الكحول والتبغ"

--- a/gotext.go
+++ b/gotext.go
@@ -171,7 +171,20 @@ func GetN(str, plural string, n int, vars ...interface{}) string {
 // GetD returns the corresponding Translation in the given domain for a given string.
 // Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
 func GetD(dom, str string, vars ...interface{}) string {
-	return GetND(dom, str, str, 1, vars...)
+	// Try to load default package Locale storage
+	loadStorage(false)
+
+	// Return Translation
+	globalConfig.RLock()
+
+	if _, ok := globalConfig.storage.Domains[dom]; !ok {
+		globalConfig.storage.AddDomain(dom)
+	}
+
+	tr := globalConfig.storage.GetD(dom, str, vars...)
+	globalConfig.RUnlock()
+
+	return tr
 }
 
 // GetND retrieves the (N)th plural form of Translation in the given domain for a given string.
@@ -208,7 +221,15 @@ func GetNC(str, plural string, n int, ctx string, vars ...interface{}) string {
 // GetDC returns the corresponding Translation in the given domain for the given string in the given context.
 // Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
 func GetDC(dom, str, ctx string, vars ...interface{}) string {
-	return GetNDC(dom, str, str, 1, ctx, vars...)
+	// Try to load default package Locale storage
+	loadStorage(false)
+
+	// Return Translation
+	globalConfig.RLock()
+	tr := globalConfig.storage.GetDC(dom, str, ctx, vars...)
+	globalConfig.RUnlock()
+
+	return tr
 }
 
 // GetNDC retrieves the (N)th plural form of Translation in the given domain for a given string.

--- a/gotext_test.go
+++ b/gotext_test.go
@@ -452,3 +452,60 @@ msgstr "Some random Translation in a context"
 
 	wg.Wait()
 }
+
+func TestPackageArabicTranslation(t *testing.T) {
+	Configure("fixtures/", "ar", "categories")
+
+	// Plurals formula missing + Plural translation string missing
+	tr := GetD("categories", "Alcohol & Tobacco")
+	if tr != "الكحول والتبغ" {
+		t.Errorf("Expected to get 'الكحول والتبغ', but got '%s'", tr)
+	}
+
+	// Plural translation string present without translations, should get the msgid_plural
+	tr = GetND("categories", "%d selected", "%d selected", 10)
+	if tr != "%d selected" {
+		t.Errorf("Expected to get '%%d selected', but got '%s'", tr)
+	}
+
+	//Plurals formula present + Plural translation string present and complete
+	tr = GetND("categories", "Load %d more document", "Load %d more documents", 0)
+	if tr != "حمّل %d مستندات إضافيّة" {
+		t.Errorf("Expected to get 'msgstr[0]', but got '%s'", tr)
+	}
+
+	tr = GetND("categories", "Load %d more document", "Load %d more documents", 1)
+	if tr != "حمّل مستند واحد إضافي" {
+		t.Errorf("Expected to get 'msgstr[1]', but got '%s'", tr)
+	}
+
+	tr = GetND("categories", "Load %d more document", "Load %d more documents", 2)
+	if tr != "حمّل مستندين إضافيين" {
+		t.Errorf("Expected to get 'msgstr[2]', but got '%s'", tr)
+	}
+
+	tr = GetND("categories", "Load %d more document", "Load %d more documents", 6)
+	if tr != "حمّل %d مستندات إضافيّة" {
+		t.Errorf("Expected to get 'msgstr[3]', but got '%s'", tr)
+	}
+
+	tr = GetND("categories", "Load %d more document", "Load %d more documents", 116)
+	if tr != "حمّل %d مستندا إضافيّا" {
+		t.Errorf("Expected to get 'msgstr[4]', but got '%s'", tr)
+	}
+
+	tr = GetND("categories", "Load %d more document", "Load %d more documents", 102)
+	if tr != "حمّل %d مستند إضافي" {
+		t.Errorf("Expected to get 'msgstr[5]', but got '%s'", tr)
+	}
+}
+
+func TestPackageArabicMissingPluralForm(t *testing.T) {
+	Configure("fixtures/", "ar", "no_plural_header")
+
+	// Get translation
+	tr := GetD("no_plural_header", "Alcohol & Tobacco")
+	if tr != "الكحول والتبغ" {
+		t.Errorf("Expected to get 'الكحول والتبغ', but got '%s'", tr)
+	}
+}

--- a/locale.go
+++ b/locale.go
@@ -182,7 +182,19 @@ func (l *Locale) GetN(str, plural string, n int, vars ...interface{}) string {
 // GetD returns the corresponding Translation in the given domain for the given string.
 // Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
 func (l *Locale) GetD(dom, str string, vars ...interface{}) string {
-	return l.GetND(dom, str, str, 1, vars...)
+	// Sync read
+	l.RLock()
+	defer l.RUnlock()
+
+	if l.Domains != nil {
+		if _, ok := l.Domains[dom]; ok {
+			if l.Domains[dom] != nil {
+				return l.Domains[dom].Get(str, vars...)
+			}
+		}
+	}
+
+	return Printf(str, vars...)
 }
 
 // GetND retrieves the (N)th plural form of Translation in the given domain for the given string.
@@ -222,7 +234,19 @@ func (l *Locale) GetNC(str, plural string, n int, ctx string, vars ...interface{
 // GetDC returns the corresponding Translation in the given domain for the given string in the given context.
 // Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
 func (l *Locale) GetDC(dom, str, ctx string, vars ...interface{}) string {
-	return l.GetNDC(dom, str, str, 1, ctx, vars...)
+	// Sync read
+	l.RLock()
+	defer l.RUnlock()
+
+	if l.Domains != nil {
+		if _, ok := l.Domains[dom]; ok {
+			if l.Domains[dom] != nil {
+				return l.Domains[dom].GetC(str, ctx, vars...)
+			}
+		}
+	}
+
+	return Printf(str, vars...)
 }
 
 // GetNDC retrieves the (N)th plural form of Translation in the given domain for the given string in the given context.

--- a/locale_test.go
+++ b/locale_test.go
@@ -504,8 +504,60 @@ func TestArabicTranslation(t *testing.T) {
 	// Add domain
 	l.AddDomain("categories")
 
-	// Get translation
+	// Plurals formula missing + Plural translation string missing
 	tr := l.GetD("categories", "Alcohol & Tobacco")
+	if tr != "الكحول والتبغ" {
+		t.Errorf("Expected to get 'الكحول والتبغ', but got '%s'", tr)
+	}
+
+	// Plural translation string present without translations, should get the msgid_plural
+	tr = l.GetND("categories", "%d selected", "%d selected", 10)
+	if tr != "%d selected" {
+		t.Errorf("Expected to get '%%d selected', but got '%s'", tr)
+	}
+
+	//Plurals formula present + Plural translation string present and complete
+	tr = l.GetND("categories", "Load %d more document", "Load %d more documents", 0)
+	if tr != "حمّل %d مستندات إضافيّة" {
+		t.Errorf("Expected to get 'msgstr[0]', but got '%s'", tr)
+	}
+
+	tr = l.GetND("categories", "Load %d more document", "Load %d more documents", 1)
+	if tr != "حمّل مستند واحد إضافي" {
+		t.Errorf("Expected to get 'msgstr[1]', but got '%s'", tr)
+	}
+
+	tr = l.GetND("categories", "Load %d more document", "Load %d more documents", 2)
+	if tr != "حمّل مستندين إضافيين" {
+		t.Errorf("Expected to get 'msgstr[2]', but got '%s'", tr)
+	}
+
+	tr = l.GetND("categories", "Load %d more document", "Load %d more documents", 6)
+	if tr != "حمّل %d مستندات إضافيّة" {
+		t.Errorf("Expected to get 'msgstr[3]', but got '%s'", tr)
+	}
+
+	tr = l.GetND("categories", "Load %d more document", "Load %d more documents", 116)
+	if tr != "حمّل %d مستندا إضافيّا" {
+		t.Errorf("Expected to get 'msgstr[4]', but got '%s'", tr)
+	}
+
+	tr = l.GetND("categories", "Load %d more document", "Load %d more documents", 102)
+	if tr != "حمّل %d مستند إضافي" {
+		t.Errorf("Expected to get 'msgstr[5]', but got '%s'", tr)
+	}
+
+}
+
+func TestArabicMissingPluralForm(t *testing.T) {
+	// Create Locale
+	l := NewLocale("fixtures/", "ar")
+
+	// Add domain
+	l.AddDomain("no_plural_header")
+
+	// Get translation
+	tr := l.GetD("no_plural_header", "Alcohol & Tobacco")
 	if tr != "الكحول والتبغ" {
 		t.Errorf("Expected to get 'الكحول والتبغ', but got '%s'", tr)
 	}


### PR DESCRIPTION
instead of calling Translation.GetN with a default of plural=1
* add correct Arabic plural rules to test

# Before creating your Pull Request...

- New Pull Requests should include a good description of what's being merged. 
- Ideally, all Pull Requests are preceded by a discussion initiated in an Issue on this repository. 
- For bug fixes is mandatory to have tests that cover and fail when the bug is present and will pass after this Pull Request.
- For changes and improvements, new tests have to be provided to cover the new features.


## Is this a fix, improvement or something else?
Fix (https://github.com/leonelquinteros/gotext/issues/39)
...


## What does this change implement/fix?
Adding the correct Pluralform rules in the existing Arabic test case caused it to fail in a way that's consistent with https://github.com/leonelquinteros/gotext/issues/39
The code changes provided allowed the test to pass
... 


## I have ...

- [x] answered the 2 questions above,
- [x] discussed this change in an issue,
- [x] included tests to cover this changes.
