### PR TITLE
Add GetTranslations methods to Locale and Domain

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -401,6 +401,31 @@ func (do *Domain) GetNC(str, plural string, n int, ctx string, vars ...interface
 	return Printf(plural, vars...)
 }
 
+//GetTranslations returns a copy of every translation in the domain. It does not support contexts.
+func (do *Domain) GetTranslations() map[string]*Translation {
+	all := make(map[string]*Translation)
+
+	do.trMutex.RLock()
+	defer do.trMutex.RUnlock()
+
+	for msgID, trans := range do.translations {
+		newTrans := NewTranslation()
+		newTrans.ID = trans.ID
+		newTrans.PluralID = trans.PluralID
+		newTrans.dirty = trans.dirty
+		if len(trans.Refs) > 0 {
+			newTrans.Refs = make([]string, len(trans.Refs))
+			copy(newTrans.Refs, trans.Refs)
+		}
+		for k, v := range trans.Trs {
+			newTrans.Trs[k] = v
+		}
+		all[msgID] = newTrans
+	}
+
+	return all
+}
+
 type SourceReference struct {
 	path    string
 	line    int

--- a/domain.go
+++ b/domain.go
@@ -403,7 +403,7 @@ func (do *Domain) GetNC(str, plural string, n int, ctx string, vars ...interface
 
 //GetTranslations returns a copy of every translation in the domain. It does not support contexts.
 func (do *Domain) GetTranslations() map[string]*Translation {
-	all := make(map[string]*Translation)
+	all := make(map[string]*Translation, len(do.translations))
 
 	do.trMutex.RLock()
 	defer do.trMutex.RUnlock()

--- a/domain_test.go
+++ b/domain_test.go
@@ -2,6 +2,10 @@ package gotext
 
 import "testing"
 
+const (
+	enUSFixture = "fixtures/en_US/default.po"
+)
+
 //since both Po and Mo just pass-through to Domain for MarshalBinary and UnmarshalBinary, test it here
 func TestBinaryEncoding(t *testing.T) {
 	// Create po objects
@@ -9,7 +13,7 @@ func TestBinaryEncoding(t *testing.T) {
 	po2 := NewPo()
 
 	// Parse file
-	po.ParseFile("fixtures/en_US/default.po")
+	po.ParseFile(enUSFixture)
 
 	buff, err := po.GetDomain().MarshalBinary()
 	if err != nil {
@@ -30,5 +34,38 @@ func TestBinaryEncoding(t *testing.T) {
 	tr = po2.Get("language")
 	if tr != "en_US" {
 		t.Errorf("Expected 'en_US' but got '%s'", tr)
+	}
+}
+
+func TestDomain_GetTranslations(t *testing.T) {
+	po := NewPo()
+	po.ParseFile(enUSFixture)
+
+	domain := po.GetDomain()
+	all := domain.GetTranslations()
+
+	if len(all) != len(domain.translations) {
+		t.Error("lengths should match")
+	}
+
+	for k, v := range domain.translations {
+		if all[k] == v {
+			t.Error("GetTranslations should be returning a copy, but pointers are equal")
+		}
+		if all[k].ID != v.ID {
+			t.Error("IDs should match")
+		}
+		if all[k].PluralID != v.PluralID {
+			t.Error("PluralIDs should match")
+		}
+		if all[k].dirty != v.dirty {
+			t.Error("dirty flag should match")
+		}
+		if len(all[k].Trs) != len(v.Trs) {
+			t.Errorf("Trs length does not match: %d != %d", len(all[k].Trs), len(v.Trs))
+		}
+		if len(all[k].Refs) != len(v.Refs) {
+			t.Errorf("Refs length does not match: %d != %d", len(all[k].Refs), len(v.Refs))
+		}
 	}
 }

--- a/locale.go
+++ b/locale.go
@@ -271,6 +271,21 @@ func (l *Locale) GetNDC(dom, str, plural string, n int, ctx string, vars ...inte
 	return Printf(plural, vars...)
 }
 
+//GetTranslations returns a copy of all translations in all domains of this locale. It does not support contexts.
+func (l *Locale) GetTranslations() map[string]*Translation {
+	all := make(map[string]*Translation)
+
+	l.RLock()
+	defer l.RUnlock()
+	for _, translator := range l.Domains {
+		for msgID, trans := range translator.GetDomain().GetTranslations() {
+			all[msgID] = trans
+		}
+	}
+
+	return all
+}
+
 // LocaleEncoding is used as intermediary storage to encode Locale objects to Gob.
 type LocaleEncoding struct {
 	Path          string

--- a/locale_test.go
+++ b/locale_test.go
@@ -601,3 +601,23 @@ func TestLocaleBinaryEncoding(t *testing.T) {
 		t.Errorf("'%s' is different from '%s", l.GetN("One with var: %s", "Several with vars: %s", 3, "VALUE"), l2.GetN("One with var: %s", "Several with vars: %s", 3, "VALUE"))
 	}
 }
+
+func TestLocale_GetTranslations(t *testing.T) {
+	l := NewLocale("fixtures/", "en_US")
+	l.AddDomain("default")
+
+	all := l.GetTranslations()
+
+	if len(all) < 5 {
+		t.Errorf("length of all translations is too few: %d", len(all))
+	}
+
+	const moreMsgID = "More"
+	more, ok := all[moreMsgID]
+	if !ok {
+		t.Error("missing expected translation")
+	}
+	if more.Get() != l.Get(moreMsgID) {
+		t.Errorf("translations of msgid %s do not match: \"%s\" != \"%s\"", moreMsgID, more.Get(), l.Get(moreMsgID))
+	}
+}


### PR DESCRIPTION
Per discussion in #46, this is a simple way to allow access to all the translations in a locale. It is just iterating over all domains, and the domain method creates a copy of each translation and returns the resulting map.

This is a new feature that will make it possible to enumerate all the translations that have been loaded.

It does not support contexts as this time.

- [X] answered the 2 questions above,
- [X] discussed this change in an issue,
- [X] included tests to cover this changes.
