### PR TITLE
Fix arg type in docstring for (*Po).Parse

### DIFF
--- a/po.go
+++ b/po.go
@@ -126,7 +126,7 @@ func (po *Po) ParseFile(f string) {
 	po.Parse(data)
 }
 
-// Parse loads the translations specified in the provided string (str)
+// Parse loads the translations specified in the provided byte slice (buf)
 func (po *Po) Parse(buf []byte) {
 	if po.domain == nil {
 		panic("NewPo() was not used to instantiate this object")


### PR DESCRIPTION
## Is this a fix, improvement or something else?

Documentation fix.

## What does this change implement/fix?

The Godoc string for `(*Po).Parse` currently does not match the function's signature.

## I have ...

- [x] answered the 2 questions above,
- [ ] discussed this change in an issue,
- [ ] included tests to cover this changes.
