### PR TITLE
Format quotation marks and newlines for PO export

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -3,6 +3,7 @@ package gotext
 import (
 	"bytes"
 	"encoding/gob"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -589,22 +590,28 @@ func (do *Domain) MarshalText() ([]byte, error) {
 		}
 
 		if ref.context == "" {
-			buf.WriteString("\nmsgid \"" + trans.ID + "\"")
+			buf.WriteString("\nmsgid \"" + EscapeSpecialCharacters(trans.ID) + "\"")
 		} else {
-			buf.WriteString("\nmsgctxt \"" + ref.context + "\"\nmsgid \"" + trans.ID + "\"")
+			buf.WriteString("\nmsgctxt \"" + EscapeSpecialCharacters(ref.context) + "\"\nmsgid \"" + EscapeSpecialCharacters(trans.ID) + "\"")
 		}
 
 		if trans.PluralID == "" {
-			buf.WriteString("\nmsgstr \"" + trans.Trs[0] + "\"")
+			buf.WriteString("\nmsgstr \"" + EscapeSpecialCharacters(trans.Trs[0]) + "\"")
 		} else {
 			buf.WriteString("\nmsgid_plural \"" + trans.PluralID + "\"")
 			for i, tr := range trans.Trs {
-				buf.WriteString("\nmsgstr[" + strconv.Itoa(i) + "] \"" + tr + "\"")
+				buf.WriteString("\nmsgstr[" + EscapeSpecialCharacters(strconv.Itoa(i)) + "] \"" + tr + "\"")
 			}
 		}
 	}
 
 	return buf.Bytes(), nil
+}
+
+func EscapeSpecialCharacters(s string) string {
+	s = regexp.MustCompile(`([^\\])(")`).ReplaceAllString(s, "$1\\\"")  // Escape non-escaped double quotation marks
+	s = strings.ReplaceAll(s, "\n", "\"\n\"") // Convert newlines into multi-line strings
+	return s 
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler interface

--- a/domain_test.go
+++ b/domain_test.go
@@ -1,6 +1,9 @@
 package gotext
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 const (
 	enUSFixture = "fixtures/en_US/default.po"
@@ -67,5 +70,22 @@ func TestDomain_GetTranslations(t *testing.T) {
 		if len(all[k].Refs) != len(v.Refs) {
 			t.Errorf("Refs length does not match: %d != %d", len(all[k].Refs), len(v.Refs))
 		}
+	}
+}
+
+func TestDomain_CheckExportFormatting(t *testing.T) {
+	po := NewPo()
+	po.Set("myid", "test string\nwith \"newline\"")
+	poBytes, _ := po.MarshalText()
+
+	expectedOutput := `msgid ""
+msgstr ""
+
+msgid "myid"
+msgstr "test string"
+"with \"newline\""`
+	
+	if string(poBytes) != expectedOutput {
+		t.Errorf("Exported PO format does not match. Received:\n\n%v\n\n\nExpected:\n\n%v", string(poBytes), expectedOutput)
 	}
 }

--- a/domain_test.go
+++ b/domain_test.go
@@ -1,7 +1,6 @@
 package gotext
 
 import (
-	"fmt"
 	"testing"
 )
 


### PR DESCRIPTION
Fixes https://github.com/leonelquinteros/gotext/issues/60.

As described in the issue, this:

```
	po := gotext.NewPo()
	strings := map[string]string{"myid": "test string\nwith \"newline\""}
	for k, v := range strings {
		po.Set(k, v)
	}
	po_bytes, _ := po.MarshalText()
	fmt.Println(string(po_bytes))
```

currently outputs this:

```
msgid ""
msgstr ""

msgid "myid"
msgstr "test string
with "newline""
```

This breaks format and causes xgettext to throw errors if the file is used. After this PR, the output is:

```
[...]
msgid "myid"
msgstr "test string"
"with \"newline\""
``` 

My apologies for not adding tests. Please feel free to edit/push to this branch.