### PR TITLE
Fix #59

### DIFF
--- a/cli/xgotext/fixtures/main.go
+++ b/cli/xgotext/fixtures/main.go
@@ -36,6 +36,14 @@ func main() {
 	// same as before
 	fmt.Println(gotext.Get("My text on 'domain-name' domain"))
 
+	// Multiline with string
+	fmt.Println(gotext.Get("This is a string addition. " +
+		"Which is merged."))
+
+	// Multiline with raw string literal
+	fmt.Print(gotext.Get(`This is a multiline string.
+It should be formatted properly in a .pot file.`))
+
 	// unsupported function call
 	trStr := "some string to translate"
 	fmt.Println(gotext.Get(trStr))

--- a/cli/xgotext/parser/dir/golang.go
+++ b/cli/xgotext/parser/dir/golang.go
@@ -251,7 +251,7 @@ func (g *GoFile) parseGetter(def GetterDef, args []*string, pos string) {
 	}
 
 	trans := parser.Translation{
-		MsgId:           parser.PrepareString(*args[def.Id]),
+		MsgId:           *args[def.Id],
 		SourceLocations: []string{pos},
 	}
 	if def.Plural > 0 {
@@ -260,7 +260,7 @@ func (g *GoFile) parseGetter(def GetterDef, args []*string, pos string) {
 			log.Printf("ERR: Unsupported call at %s (Plural not a string)", pos)
 			return
 		}
-		trans.MsgIdPlural = parser.PrepareString(*args[def.Plural])
+		trans.MsgIdPlural = *args[def.Plural]
 	}
 	if def.Context > 0 {
 		// Context must be a string
@@ -268,7 +268,7 @@ func (g *GoFile) parseGetter(def GetterDef, args []*string, pos string) {
 			log.Printf("ERR: Unsupported call at %s (Context not a string)", pos)
 			return
 		}
-		trans.Context = parser.PrepareString(*args[def.Context])
+		trans.Context = *args[def.Context]
 	}
 
 	g.data.AddTranslation(domain, &trans)

--- a/cli/xgotext/parser/pkg-tree/golang.go
+++ b/cli/xgotext/parser/pkg-tree/golang.go
@@ -288,7 +288,7 @@ func (g *GoFile) parseGetter(def GetterDef, args []*string, pos string) {
 	}
 
 	trans := parser.Translation{
-		MsgId:           parser.PrepareString(*args[def.Id]),
+		MsgId:           *args[def.Id],
 		SourceLocations: []string{pos},
 	}
 	if def.Plural > 0 {
@@ -297,7 +297,7 @@ func (g *GoFile) parseGetter(def GetterDef, args []*string, pos string) {
 			log.Printf("ERR: Unsupported call at %s (Plural not a string)", pos)
 			return
 		}
-		trans.MsgIdPlural = parser.PrepareString(*args[def.Plural])
+		trans.MsgIdPlural = *args[def.Plural]
 	}
 	if def.Context > 0 {
 		// Context must be a string
@@ -305,7 +305,7 @@ func (g *GoFile) parseGetter(def GetterDef, args []*string, pos string) {
 			log.Printf("ERR: Unsupported call at %s (Context not a string)", pos)
 			return
 		}
-		trans.Context = parser.PrepareString(*args[def.Context])
+		trans.Context = *args[def.Context]
 	}
 
 	g.data.AddTranslation(domain, &trans)

--- a/cli/xgotext/parser/pkg-tree/golang_test.go
+++ b/cli/xgotext/parser/pkg-tree/golang_test.go
@@ -1,10 +1,12 @@
 package pkg_tree
 
 import (
-	"github.com/leonelquinteros/gotext/cli/xgotext/parser"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
+
+	"github.com/leonelquinteros/gotext/cli/xgotext/parser"
 )
 
 func TestParsePkgTree(t *testing.T) {
@@ -23,7 +25,22 @@ func TestParsePkgTree(t *testing.T) {
 		t.Error(err)
 	}
 
-	translations := []string{"\"inside sub package\"", "\"My text on 'domain-name' domain\"", "\"alias call\"", "\"Singular\"", "\"SingularVar\"", "\"translate package\"", "\"translate sub package\"", "\"inside dummy\""}
+	translations := []string{
+		"inside sub package",
+		"My text on 'domain-name' domain",
+		"This is a string addition. Which is merged.",
+		"This is a multiline string.\nIt should be formatted properly in a .pot file.",
+		"alias call",
+		"Singular",
+		"SingularVar",
+		"translate package",
+		"translate sub package",
+		"inside dummy",
+	}
+
+	for idx, translation := range translations {
+		translations[idx] = strconv.Quote(translation)
+	}
 
 	if len(translations) != len(data.Domains[defaultDomain].Translations) {
 		t.Error("translations count mismatch")

--- a/cli/xgotext/parser/utils.go
+++ b/cli/xgotext/parser/utils.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// ExtractStringLiteral checks if an expression is a string and returns it.
+// ExtractStringLiteral checks if an expression represents a string and returns it correctly formatted.
 func ExtractStringLiteral(expr ast.Expr) (string, bool) {
 	stack := []ast.Expr{expr}
 	result := ""

--- a/cli/xgotext/parser/utils.go
+++ b/cli/xgotext/parser/utils.go
@@ -6,16 +6,6 @@ import (
 	"strconv"
 )
 
-func PrepareString(rawString string) string {
-	// Remove backquotes and add quotes
-	unquoteString, err := strconv.Unquote(rawString)
-	if err != nil {
-		return rawString
-	}
-
-	return strconv.Quote(unquoteString)
-}
-
 // ExtractStringLiteral checks if an expression is a string and returns it.
 func ExtractStringLiteral(expr ast.Expr) (string, bool) {
 	stack := []ast.Expr{expr}
@@ -49,5 +39,15 @@ func ExtractStringLiteral(expr ast.Expr) (string, bool) {
 		}
 	}
 
-	return strconv.Quote(result), true
+	return prepareString(result), true
+}
+
+func prepareString(rawString string) string {
+	// Remove backquotes and add quotes
+	unquoteString, err := strconv.Unquote(rawString)
+	if err != nil {
+		return strconv.Quote(rawString)
+	}
+
+	return strconv.Quote(unquoteString)
 }

--- a/cli/xgotext/parser/utils.go
+++ b/cli/xgotext/parser/utils.go
@@ -1,0 +1,53 @@
+package parser
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+)
+
+func PrepareString(rawString string) string {
+	// Remove backquotes and add quotes
+	unquoteString, err := strconv.Unquote(rawString)
+	if err != nil {
+		return rawString
+	}
+
+	return strconv.Quote(unquoteString)
+}
+
+// ExtractStringLiteral checks if an expression is a string and returns it.
+func ExtractStringLiteral(expr ast.Expr) (string, bool) {
+	stack := []ast.Expr{expr}
+	result := ""
+
+	for len(stack) != 0 {
+		n := len(stack) - 1
+		elem := stack[n]
+		stack = stack[:n]
+
+		switch v := elem.(type) {
+		//  Simple string with quotes or backqoutes
+		case *ast.BasicLit:
+			if v.Kind != token.STRING {
+				return "", false
+			}
+
+			if unqouted, err := strconv.Unquote(v.Value); err != nil {
+				result = v.Value + result
+			} else {
+				result = unqouted + result
+			}
+		// Concatenation of several string literals
+		case *ast.BinaryExpr:
+			if v.Op != token.ADD {
+				return "", false
+			}
+			stack = append(stack, v.X, v.Y)
+		default:
+			return "", false
+		}
+	}
+
+	return strconv.Quote(result), true
+}

--- a/cli/xgotext/parser/utils.go
+++ b/cli/xgotext/parser/utils.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/token"
 	"strconv"
+	"strings"
 )
 
 // ExtractStringLiteral checks if an expression is a string and returns it.
@@ -43,6 +44,10 @@ func ExtractStringLiteral(expr ast.Expr) (string, bool) {
 }
 
 func prepareString(rawString string) string {
+	if strings.HasPrefix(rawString, `"`) && strings.HasSuffix(rawString, `"`) {
+		return rawString
+	}
+
 	// Remove backquotes and add quotes
 	unquoteString, err := strconv.Unquote(rawString)
 	if err != nil {

--- a/cli/xgotext/parser/utils_test.go
+++ b/cli/xgotext/parser/utils_test.go
@@ -34,7 +34,7 @@ func TestPrepareString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := PrepareString(tt.raw); got != tt.want {
+			if got := prepareString(tt.raw); got != tt.want {
 				t.Errorf("PrepareString() = %v, want %v", got, tt.want)
 			}
 		})

--- a/cli/xgotext/parser/utils_test.go
+++ b/cli/xgotext/parser/utils_test.go
@@ -1,0 +1,95 @@
+package parser
+
+import (
+	"go/parser"
+	"testing"
+)
+
+func TestPrepareString(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "Quotation marks are preserved",
+			raw:  "\"Extracted string\"",
+			want: "\"Extracted string\"",
+		},
+		{
+			name: "Backquotes are replaced",
+			raw:  "`Extracted string`",
+			want: "\"Extracted string\"",
+		},
+		{
+			name: "Intentional multiple quotation marks are preserved",
+			raw:  "\"\"Extracted string\"\"",
+			want: "\"\"Extracted string\"\"",
+		},
+		{
+			name: "Intentional backquotes are preserved",
+			raw:  "\"`Extracted string`\"",
+			want: "\"`Extracted string`\"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PrepareString(tt.raw); got != tt.want {
+				t.Errorf("PrepareString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractStringLiteral(t *testing.T) {
+	tests := []struct {
+		name      string
+		code      string
+		wantStr   string
+		wantFound bool
+	}{
+		{
+			name:      "String extracted",
+			code:      `"Extracted string"`,
+			wantStr:   `"Extracted string"`,
+			wantFound: true,
+		},
+		{
+			name:      "Even addition is merged",
+			code:      `"Extracted " + "string"`,
+			wantStr:   `"Extracted string"`,
+			wantFound: true,
+		},
+		{
+			name:      "Odd addition is merged",
+			code:      `"Extracted " + "string" + " is combined"`,
+			wantStr:   `"Extracted string is combined"`,
+			wantFound: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr, err := parser.ParseExpr(tt.code)
+			if err != nil {
+				t.Errorf("Expression %s could not be parsed: %v", tt.code, expr)
+			}
+			extractedStr, found := ExtractStringLiteral(expr)
+			if extractedStr != tt.wantStr {
+				t.Errorf("ExtractStringLiteral() string = %v, want %v", extractedStr, tt.wantStr)
+			}
+			if found != tt.wantFound {
+				t.Errorf("ExtractStringLiteral() got1 = %v, want %v", found, tt.wantFound)
+			}
+		})
+	}
+
+	t.Run("Nil is ignored", func(t *testing.T) {
+		extractedStr, found := ExtractStringLiteral(nil)
+		if extractedStr != "" {
+			t.Errorf("ExtractStringLiteral() string = %v, want %v", extractedStr, "")
+		}
+		if found != false {
+			t.Errorf("ExtractStringLiteral() got1 = %v, want %v", found, false)
+		}
+	})
+}


### PR DESCRIPTION
## Is this a fix, improvement or something else?

Fix and Improvement for xgotext

## What does this change implement/fix?

* Fix #59. Backqoutes are now replaced by quotes when extracting with xgotext.
* The concatenation of string literals is detected and the merged string is extracted. 

## I have ...

- [x] answered the 2 questions above,
- [ ] discussed this change in an issue,
- [x] included tests to cover this changes.
