### PR TITLE
Changing the copyright header for plurals package

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,37 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+Package `plurals`
+
+Original:
+    https://github.com/ojii/gettext.go/tree/b6dae1d7af8a8441285e42661565760b530a8a57/pluralforms
+
+License:
+    https://raw.githubusercontent.com/ojii/gettext.go/b6dae1d7af8a8441285e42661565760b530a8a57/LICENSE
+
+    Copyright (c) 2016, Jonas Obrist
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above copyright
+          notice, this list of conditions and the following disclaimer in the
+          documentation and/or other materials provided with the distribution.
+        * Neither the name of Jonas Obrist nor the
+          names of its contributors may be used to endorse or promote products
+          derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL JONAS OBRIST BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/plurals/compiler.go
+++ b/plurals/compiler.go
@@ -1,10 +1,11 @@
-/*
- * Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com. All rights reserved.
- * Licensed under the MIT License. See LICENSE file in the project root for full license information.
- */
+// Original work Copyright (c) 2016 Jonas Obrist (https://github.com/ojii/gettext.go)
+// Modified work Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com
+// Modified work Copyright (c) 2018-present gotext maintainers (https://github.com/leonelquinteros/gotext)
+//
+// Licensed under the 3-Clause BSD License. See LICENSE in the project root for license information.
 
 /*
- Package plurals is the pluralform compiler to get the correct translation id of the plural string
+Package plurals is the pluralform compiler to get the correct translation id of the plural string
 */
 package plurals
 

--- a/plurals/compiler_test.go
+++ b/plurals/compiler_test.go
@@ -1,7 +1,8 @@
-/*
- * Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com. All rights reserved.
- * Licensed under the MIT License. See LICENSE file in the project root for full license information.
- */
+// Original work Copyright (c) 2016 Jonas Obrist (https://github.com/ojii/gettext.go)
+// Modified work Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com
+// Modified work Copyright (c) 2018-present gotext maintainers (https://github.com/leonelquinteros/gotext)
+//
+// Licensed under the 3-Clause BSD License. See LICENSE in the project root for license information.
 
 package plurals
 

--- a/plurals/expression.go
+++ b/plurals/expression.go
@@ -1,7 +1,8 @@
-/*
- * Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com. All rights reserved.
- * Licensed under the MIT License. See LICENSE file in the project root for full license information.
- */
+// Original work Copyright (c) 2016 Jonas Obrist (https://github.com/ojii/gettext.go)
+// Modified work Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com
+// Modified work Copyright (c) 2018-present gotext maintainers (https://github.com/leonelquinteros/gotext)
+//
+// Licensed under the 3-Clause BSD License. See LICENSE in the project root for license information.
 
 package plurals
 

--- a/plurals/genfixture.py
+++ b/plurals/genfixture.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2016 Jonas Obrist (https://github.com/ojii/gettext.go)
+#
+# Licensed under the 3-Clause BSD License. See LICENSE in the project root for license information.
+
+import json
+from gettext import c2py
+
+
+PLURAL_FORMS = [
+    "0",
+    "n!=1",
+    "n>1",
+    "n%10==1&&n%100!=11?0:n!=0?1:2",
+    "n==1?0:n==2?1:2",
+    "n==1?0:(n==0||(n%100>0&&n%100<20))?1:2",
+    "n%10==1&&n%100!=11?0:n%10>=2&&(n%100<10||n%100>=20)?1:2",
+    "n%10==1&&n%100!=11?0:n%10>=2&&n%10<=4&&(n%100<10||n%100>=20)?1:2",
+    "(n==1)?0:(n>=2&&n<=4)?1:2",
+    "n==1?0:n%10>=2&&n%10<=4&&(n%100<10||n%100>=20)?1:2",
+    "n%100==1?0:n%100==2?1:n%100==3||n%100==4?2:3",
+    "n==0?0:n==1?1:n==2?2:n%100>=3&&n%100<=10?3:n%100>=11?4:5",
+]
+
+NUM = 1000
+
+
+def gen():
+    tests = []
+    for plural_form in PLURAL_FORMS:
+        expr = c2py(plural_form)
+        tests.append({
+            'pluralform': plural_form,
+            'fixture': [expr(n) for n in range(NUM + 1)]
+        })
+    return json.dumps(tests)
+
+
+if __name__ == "__main__":
+    print(gen())

--- a/plurals/math.go
+++ b/plurals/math.go
@@ -1,7 +1,8 @@
-/*
- * Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com. All rights reserved.
- * Licensed under the MIT License. See LICENSE file in the project root for full license information.
- */
+// Original work Copyright (c) 2016 Jonas Obrist (https://github.com/ojii/gettext.go)
+// Modified work Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com
+// Modified work Copyright (c) 2018-present gotext maintainers (https://github.com/leonelquinteros/gotext)
+//
+// Licensed under the 3-Clause BSD License. See LICENSE in the project root for license information.
 
 package plurals
 

--- a/plurals/tests.go
+++ b/plurals/tests.go
@@ -1,7 +1,8 @@
-/*
- * Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com. All rights reserved.
- * Licensed under the MIT License. See LICENSE file in the project root for full license information.
- */
+// Original work Copyright (c) 2016 Jonas Obrist (https://github.com/ojii/gettext.go)
+// Modified work Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com
+// Modified work Copyright (c) 2018-present gotext maintainers (https://github.com/leonelquinteros/gotext)
+//
+// Licensed under the BSD License. See License.txt in the project root for license information.
 
 package plurals
 


### PR DESCRIPTION
## Is this a fix, improvement or something else?

Mhh... :thinking: Something else.


## What does this change implement/fix?

It is a suggestion how to adjust the copyright header for the plurals package so that no rights of the original authors and no licenses are violated.

I am not a lawyer and have no legal education. This is just a suggestion so that Issue #50 can be closed and everyone is happy.


## I have ...

- [x] answered the 2 questions above,
- [ ] discussed this change in an issue,
- [ ] included tests to cover this changes.
