### PR TITLE
feat: Add language getter for Locale

### DIFF
--- a/locale.go
+++ b/locale.go
@@ -192,6 +192,14 @@ func (l *Locale) SetDomain(dom string) {
 	l.Unlock()
 }
 
+// GetLanguage is the lang getter for Locale configuration
+func (l *Locale) GetLanguage() string {
+	l.RLock()
+	lang := l.lang
+	l.RUnlock()
+	return lang
+}
+
 // Get uses a domain "default" to return the corresponding Translation of a given string.
 // Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
 func (l *Locale) Get(str string, vars ...interface{}) string {

--- a/locale_test.go
+++ b/locale_test.go
@@ -226,6 +226,12 @@ msgstr "More Translation"
 	// Create Locale with full language code
 	l := NewLocale("/tmp", "en_US")
 
+	// Test language
+	language := l.GetLanguage()
+	if language != "en_US" {
+		t.Errorf("Expected 'en_US' but got '%s'", language)
+	}
+
 	// Force nil domain storage
 	l.Domains = nil
 
@@ -293,6 +299,12 @@ msgstr "More Translation"
 	// Create Locale with full language code
 	l = NewLocale("/tmp", "golem")
 
+	// Test language
+	language = l.GetLanguage()
+	if language != "golem" {
+		t.Errorf("Expected 'golem' but got '%s'", language)
+	}
+
 	// Force nil domain storage
 	l.Domains = nil
 
@@ -322,6 +334,12 @@ msgstr "More Translation"
 
 	// Create Locale with full language code
 	l = NewLocale("fixtures/", "fr_FR")
+
+	// Test language
+	language = l.GetLanguage()
+	if language != "fr_FR" {
+		t.Errorf("Expected 'fr_FR' but got '%s'", language)
+	}
 
 	// Force nil domain storage
 	l.Domains = nil
@@ -353,6 +371,12 @@ msgstr "More Translation"
 	// Create Locale with full language code
 	l = NewLocale("fixtures/", "de_DE")
 
+	// Test language
+	language = l.GetLanguage()
+	if language != "de_DE" {
+		t.Errorf("Expected 'de_DE' but got '%s'", language)
+	}
+
 	// Force nil domain storage
 	l.Domains = nil
 
@@ -382,6 +406,12 @@ msgstr "More Translation"
 
 	// Create Locale with full language code
 	l = NewLocale("fixtures/", "de_AT")
+
+	// Test language
+	language = l.GetLanguage()
+	if language != "de_AT" {
+		t.Errorf("Expected 'de_AT' but got '%s'", language)
+	}
 
 	// Force nil domain storage
 	l.Domains = nil


### PR DESCRIPTION

## Is this a fix, improvement or something else?

for proposal https://github.com/leonelquinteros/gotext/issues/75


## What does this change implement/fix?

this is to expose lang from Locale with `Locale.GetLanguage`

## I have ...

- [x] answered the 2 questions above,
- [x] discussed this change in an issue,
- [x] included tests to cover this changes.
