### PR TITLE
Fix io/fs File leak

### DIFF
--- a/locale.go
+++ b/locale.go
@@ -113,13 +113,8 @@ func (l *Locale) findExt(dom, ext string) string {
 
 func (l *Locale) fileExists(filename string) bool {
 	if l.fs != nil {
-		f, err := l.fs.Open(filename)
-		if err != nil {
-			return false
-		}
-		_, err = f.Stat()
+		_, err := fs.Stat(l.fs, filename)
 		return err == nil
-
 	}
 	_, err := os.Stat(filename)
 	return err == nil


### PR DESCRIPTION
## Is this a fix, improvement or something else?

Fix


## What does this change implement/fix?

Previously, an `fs.File` was opened for `File.Stat` without being closed. This PR replaces all of that with just a `fs.Stat` which is shorter, faster and doesn't leak.


## I have ...

- [x] answered the 2 questions above,
- [ ] discussed this change in an issue,
- [ ] included tests to cover this changes.
