### PR TITLE
Fix multiline export

### DIFF
--- a/cli/xgotext/fixtures/i18n/default.po
+++ b/cli/xgotext/fixtures/i18n/default.po
@@ -7,22 +7,80 @@ msgstr ""
 "Language: \n"
 "X-Generator: xgotext\n"
 
-	
-#: fixtures/main.go:23
-#. gotext.Get
+#: fixtures/main.go:35
+#: fixtures/main.go:37
 msgid "My text on 'domain-name' domain"
 msgstr ""
 
-#: fixtures/main.go:38
-#. l.GetN
+#: fixtures/main.go:75
 msgid "Singular"
 msgid_plural "Plural"
 msgstr[0] ""
 msgstr[1] ""
 
-#: fixtures/main.go:40
-#. l.GetN
+#: fixtures/main.go:77
 msgid "SingularVar"
 msgid_plural "PluralVar"
 msgstr[0] ""
 msgstr[1] ""
+
+#: fixtures/main.go:44
+msgid "alias call"
+msgstr ""
+
+#: fixtures/main.go:104
+msgid "inside dummy"
+msgstr ""
+
+#: fixtures/pkg/pkg.go:15
+msgid "inside sub package"
+msgstr ""
+
+#: fixtures/main.go:51
+msgid ""
+"multi\n"
+"line\n"
+"string\n"
+msgstr ""
+
+#: fixtures/main.go:54
+msgid ""
+"multi\n"
+"line\n"
+"string\n"
+"ending with\n"
+"EOL\n"
+msgstr ""
+
+#: fixtures/main.go:59
+msgid ""
+"multline\n"
+"ending with EOL\n"
+msgstr ""
+
+#: fixtures/main.go:50
+msgid "raw string with\nmultiple\nEOL"
+msgstr ""
+
+#: fixtures/main.go:48
+msgid "string ending with EOL\n"
+msgstr ""
+
+#: fixtures/main.go:49
+msgid ""
+"string with\n"
+"multiple\n"
+"EOL\n"
+msgstr ""
+
+#: fixtures/main.go:47
+msgid "string with backquotes"
+msgstr ""
+
+#: fixtures/main.go:91
+msgid "translate package"
+msgstr ""
+
+#: fixtures/main.go:92
+msgid "translate sub package"
+msgstr ""

--- a/cli/xgotext/fixtures/i18n/domain2.po
+++ b/cli/xgotext/fixtures/i18n/domain2.po
@@ -7,8 +7,11 @@ msgstr ""
 "Language: \n"
 "X-Generator: xgotext\n"
 
-	
-#: fixtures/main.go:26
-#. gotext.GetD
+#: fixtures/main.go:61
 msgid "Another text on a different domain"
+msgstr ""
+
+#: fixtures/main.go:78
+msgctxt "ctx"
+msgid "string"
 msgstr ""

--- a/cli/xgotext/fixtures/i18n/translations.po
+++ b/cli/xgotext/fixtures/i18n/translations.po
@@ -7,14 +7,11 @@ msgstr ""
 "Language: \n"
 "X-Generator: xgotext\n"
 
-	
-#: fixtures/main.go:35
-#. l.GetD
+#: fixtures/main.go:71
 msgid "Translate this"
 msgstr ""
 
-#: fixtures/main.go:43
-#. l.GetNDC
+#: fixtures/main.go:79
 msgctxt "NDC-CTX"
 msgid "ndc"
 msgid_plural "ndcs"

--- a/cli/xgotext/fixtures/main.go
+++ b/cli/xgotext/fixtures/main.go
@@ -43,6 +43,21 @@ func main() {
 	// same with alias package name
 	fmt.Println(alias.Get("alias call"))
 
+	// Special strings
+	fmt.Println(gotext.Get(`string with backquotes`))
+	fmt.Println(gotext.Get("string ending with EOL\n"))
+	fmt.Println(gotext.Get("string with\nmultiple\nEOL"))
+	fmt.Println(gotext.Get(`raw string with\nmultiple\nEOL`))
+	fmt.Println(gotext.Get(`multi
+line
+string`))
+	fmt.Println(gotext.Get(`multi
+line
+string
+ending with
+EOL`))
+	fmt.Println(gotext.Get("multline\nending with EOL\n"))
+
 	// Translate text from a different domain without reconfigure
 	fmt.Println(gotext.GetD("domain2", "Another text on a different domain"))
 

--- a/cli/xgotext/parser/dir/golang.go
+++ b/cli/xgotext/parser/dir/golang.go
@@ -248,8 +248,9 @@ func (g *GoFile) parseGetter(def GetterDef, args []*ast.BasicLit, pos string) {
 		return
 	}
 
+	msgID, _ := strconv.Unquote(args[def.Id].Value)
 	trans := parser.Translation{
-		MsgId:           args[def.Id].Value,
+		MsgId:           msgID,
 		SourceLocations: []string{pos},
 	}
 	if def.Plural > 0 {
@@ -258,7 +259,8 @@ func (g *GoFile) parseGetter(def GetterDef, args []*ast.BasicLit, pos string) {
 			log.Printf("ERR: Unsupported call at %s (Plural not a string)", pos)
 			return
 		}
-		trans.MsgIdPlural = args[def.Plural].Value
+		msgIDPlural, _ := strconv.Unquote(args[def.Plural].Value)
+		trans.MsgIdPlural = msgIDPlural
 	}
 	if def.Context > 0 {
 		// Context must be a string

--- a/cli/xgotext/parser/pkg-tree/golang.go
+++ b/cli/xgotext/parser/pkg-tree/golang.go
@@ -17,7 +17,6 @@ import (
 
 const gotextPkgPath = "github.com/leonelquinteros/gotext"
 
-
 type GetterDef struct {
 	Id      int
 	Plural  int
@@ -287,8 +286,9 @@ func (g *GoFile) parseGetter(def GetterDef, args []*ast.BasicLit, pos string) {
 		return
 	}
 
+	msgID, _ := strconv.Unquote(args[def.Id].Value)
 	trans := parser.Translation{
-		MsgId:           args[def.Id].Value,
+		MsgId:           msgID,
 		SourceLocations: []string{pos},
 	}
 	if def.Plural > 0 {
@@ -297,7 +297,8 @@ func (g *GoFile) parseGetter(def GetterDef, args []*ast.BasicLit, pos string) {
 			log.Printf("ERR: Unsupported call at %s (Plural not a string)", pos)
 			return
 		}
-		trans.MsgIdPlural = args[def.Plural].Value
+		msgIDPlural, _ := strconv.Unquote(args[def.Plural].Value)
+		trans.MsgIdPlural = msgIDPlural
 	}
 	if def.Context > 0 {
 		// Context must be a string

--- a/cli/xgotext/parser/pkg-tree/golang_test.go
+++ b/cli/xgotext/parser/pkg-tree/golang_test.go
@@ -1,10 +1,11 @@
 package pkg_tree
 
 import (
-	"github.com/leonelquinteros/gotext/cli/xgotext/parser"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/leonelquinteros/gotext/cli/xgotext/parser"
 )
 
 func TestParsePkgTree(t *testing.T) {
@@ -23,7 +24,18 @@ func TestParsePkgTree(t *testing.T) {
 		t.Error(err)
 	}
 
-	translations := []string{"\"inside sub package\"", "\"My text on 'domain-name' domain\"", "\"alias call\"", "\"Singular\"", "\"SingularVar\"", "\"translate package\"", "\"translate sub package\"", "\"inside dummy\""}
+	translations := []string{"inside sub package", "My text on 'domain-name' domain", "alias call", "Singular", "SingularVar", "translate package", "translate sub package", "inside dummy",
+		`string with backquotes`, "string ending with EOL\n", "string with\nmultiple\nEOL", `raw string with\nmultiple\nEOL`,
+		`multi
+line
+string`,
+		`multi
+line
+string
+ending with
+EOL`,
+		"multline\nending with EOL\n",
+	}
 
 	if len(translations) != len(data.Domains[defaultDomain].Translations) {
 		t.Error("translations count mismatch")

--- a/domain_test.go
+++ b/domain_test.go
@@ -134,9 +134,10 @@ func TestDomain_CheckExportFormatting(t *testing.T) {
 msgstr ""
 
 msgid "myid"
-msgstr "test string"
+msgstr ""
+"test string\n"
 "with \"newline\""`
-	
+
 	if string(poBytes) != expectedOutput {
 		t.Errorf("Exported PO format does not match. Received:\n\n%v\n\n\nExpected:\n\n%v", string(poBytes), expectedOutput)
 	}


### PR DESCRIPTION
# Before creating your Pull Request...

## Is this a fix, improvement or something else?

This is fix on multiline and backquote supports for i18n pot and po file export.

## What does this change implement/fix?

This changes impacts both the xgettext tooling and po file marshalling to text to conform to gettext specification: https://www.gnu.org/software/gettext/manual/html_node/Normalizing.html

When exporting from a po and extracting text from files, there are multiple issues for multi-line and backquotes usage. This is fine until we use standard gettext tooling for compiling them to mo files.

multilines are printed as is, instead of follow the gettext spec ( )
strings with backquotes as printed as “msgid this is my string”, which then can’t be compiled to mo files.
multilines strings with backquotes are formatted as multi-lines to, without closing quotes on each lines.
The loading is correct though, this only impact the generation file. Those generated files are thus then invalid and can’t be compile to mo file.

Check https://github.com/leonelquinteros/gotext/issues/81 for the general use cases transformation of po files.

Tests have been updated and some added.

## I have ...

- [X] answered the 2 questions above,
- [ ] Not discussed this change in an issue (just opened the issue),
- [X] included tests to cover this changes.
