### PR TITLE
Order locations in ascii order

### DIFF
--- a/cli/xgotext/parser/domain.go
+++ b/cli/xgotext/parser/domain.go
@@ -29,7 +29,9 @@ func (t *Translation) AddLocations(locations []string) {
 func (t *Translation) Dump() string {
 	data := make([]string, 0, len(t.SourceLocations)+5)
 
-	for _, location := range t.SourceLocations {
+	locations := t.SourceLocations
+	sort.Strings(locations)
+	for _, location := range locations {
 		data = append(data, "#: "+location)
 	}
 


### PR DESCRIPTION
# Before creating your Pull Request...

- New Pull Requests should include a good description of what's being merged. 
- Ideally, all Pull Requests are preceded by a discussion initiated in an Issue on this repository. 
- For bug fixes is mandatory to have tests that cover and fail when the bug is present and will pass after this Pull Request.
- For changes and improvements, new tests have to be provided to cover the new features.

## Is this a fix, improvement or something else?

This is a fix.

Before we could get some different order on consecutive runs when running the pkgtree:

```
#: cmd/foo/client/version.go:27
#: cmd/foo/daemon/version.go:23
#: cmd/bar/commands/version.go:24
msgid "some string"
msgstr ""
```

But sometimes, the dependency order could become:

```
#: cmd/foo/daemon/version.go:23
#: cmd/foo/client/version.go:27
#: cmd/bar/commands/version.go:24
msgid "some string"
msgstr ""
```


## What does this change implement/fix?

As in the pkg-tree implementation, the walking of different dependencies are not determinated, this means that we may have references swapping between consecutive runs. Ensure we always order them the same way now.

Unfortunately, there is no tests to cover that use case (also, the order is random, so it means we would need to run in a non trivial project with a lot of dependencies this tests and regenerate more than ten times). Also, this only impacts the pot file generation, so no code supposed to be running in production. I ensured there is no regression though.

## I have ...

- [X] answered the 2 questions above,
- [x] discussed this change in an issue, -> Trivial change, I can open a bug if desired but that will be a repetition of this
- [x] included tests to cover this changes. -> See my comment on test above
