### PR TITLE
Remove unused dependency

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"sync"
 
-	"golang.org/x/text/language"
-
 	"github.com/leonelquinteros/gotext/plurals"
 )
 
@@ -22,7 +20,6 @@ type Domain struct {
 
 	// Language header
 	Language string
-	tag      language.Tag
 
 	// Plural-Forms header
 	PluralForms string
@@ -143,7 +140,6 @@ func (do *Domain) parseHeaders() {
 
 	// Get/save needed headers
 	do.Language = do.Headers.Get(languageKey)
-	do.tag = language.Make(do.Language)
 	do.PluralForms = do.Headers.Get(pluralFormsKey)
 
 	// Parse Plural-Forms formula

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/leonelquinteros/gotext
 
 // go: no requirements found in Gopkg.lock
 
-require (
-	golang.org/x/text v0.3.8
-	golang.org/x/tools v0.1.12
-)
+require golang.org/x/tools v0.1.12
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
-golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
-golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=


### PR DESCRIPTION
## Is this a fix, improvement or something else?

It's an improvement.

## What does this change implement/fix?

I'm currently looking for Go gettext implementations for a private project and came across this really great looking library. Thank you very much for your work! <3 One of my criteria to select a library is how many dependencies it brings in. The fewer, the better.

While figuring out what both dependencies in gotext are used for, I quickly noticed that one is actually useless at the moment. The `tag` field is only set but never used, so it can be dropped. It was [introduced three years ago](https://github.com/leonelquinteros/gotext/commit/bb276626f3c27135c5d84addfae510979bb1c5bc) and was even not used back then. I didn't check the history any further, though. Removing the private field allows getting rid of a third-party dependency entirely.

## I have ...

- [x] answered the 2 questions above,
- [ ] discussed this change in an issue, (_Unless somebody wants to do something with the field, this change should not be controversial._)
- [ ] included tests to cover this changes. (_No new tests were added, all tests still pass._)