### PR TITLE
Fix typo in documentation

### DIFF
--- a/po.go
+++ b/po.go
@@ -25,7 +25,7 @@ Example:
 
 	func main() {
 		// Create po object
-		po := gotext.NewPoTranslator()
+		po := gotext.NewPo()
 
 		// Parse .po file
 		po.ParseFile("/path/to/po/file/translations.po")


### PR DESCRIPTION
## Is this a fix, improvement or something else?

It's a documentation fix.

## What does this change implement/fix?

There is no `NewPoTranslator` function, it's called `NewPo` instead.

## I have ...

- [x] answered the 2 questions above,
- [ ] discussed this change in an issue, (_No discussion needed, it's an obvious mistake._)
- [ ] included tests to cover this changes. (_As far as I can tell there are no tests for the documentation._)
