### PR TITLE
Add flag -no-locations

### DIFF
--- a/cli/xgotext/main.go
+++ b/cli/xgotext/main.go
@@ -11,12 +11,13 @@ import (
 )
 
 var (
-	pkgTree       = flag.String("pkg-tree", "", "main path: /path/to/go/pkg")
-	dirName       = flag.String("in", "", "input dir: /path/to/go/pkg")
-	outputDir     = flag.String("out", "", "output dir: /path/to/i18n/files")
+	pkgTree       = flag.String("pkg-tree", "", "Main path: /path/to/go/pkg")
+	dirName       = flag.String("in", "", "Input dir: /path/to/go/pkg")
+	outputDir     = flag.String("out", "", "Output dir: /path/to/i18n/files")
 	defaultDomain = flag.String("default", "default", "Name of default domain")
 	excludeDirs   = flag.String("exclude", ".git", "Comma separated list of directories to exclude")
-	verbose       = flag.Bool("v", false, "print currently handled directory")
+	noLocations   = flag.Bool("no-locations", false, "Do not write translation locations")
+	verbose       = flag.Bool("v", false, "Print currently handled directory")
 )
 
 func main() {
@@ -51,7 +52,7 @@ func main() {
 		}
 	}
 
-	err := data.Save(*outputDir)
+	err := data.Save(*outputDir, !*noLocations)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This flag controls whether translation location information is written.

## Is this a fix, improvement or something else?

An improvement.

## What does this change implement/fix?

This adds the capability to exclude translation locations from output.

## I have ...

- [X] answered the 2 questions above,
