### PR TITLE
Fix IsTranslated* functions using n directly rather than using the nth plural form

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -45,6 +45,8 @@ type Domain struct {
 	trBuffer  *Translation
 	ctxBuffer string
 	refBuffer string
+
+	customPluralResolver func(int) int
 }
 
 // Preserve MIMEHeader behaviour, without the canonicalisation
@@ -88,6 +90,10 @@ func NewDomain() *Domain {
 	return domain
 }
 
+func (do *Domain) SetPluralResolver(f func(int) int) {
+	do.customPluralResolver = f
+}
+
 func (do *Domain) pluralForm(n int) int {
 	// do we really need locking here? not sure how this plurals.Expression works, so sticking with it for now
 	do.pluralMutex.RLock()
@@ -95,6 +101,10 @@ func (do *Domain) pluralForm(n int) int {
 
 	// Failure fallback
 	if do.pluralforms == nil {
+		if do.customPluralResolver != nil {
+			return do.customPluralResolver(n)
+		}
+
 		/* Use the Germanic plural rule.  */
 		if n == 1 {
 			return 0

--- a/domain.go
+++ b/domain.go
@@ -401,7 +401,7 @@ func (do *Domain) GetNC(str, plural string, n int, ctx string, vars ...interface
 
 // IsTranslated reports whether a string is translated
 func (do *Domain) IsTranslated(str string) bool {
-	return do.IsTranslatedN(str, 0)
+	return do.IsTranslatedN(str, 1)
 }
 
 // IsTranslatedN reports whether a plural string is translated
@@ -416,12 +416,12 @@ func (do *Domain) IsTranslatedN(str string, n int) bool {
 	if !ok {
 		return false
 	}
-	return tr.IsTranslatedN(n)
+	return tr.IsTranslatedN(do.pluralForm(n))
 }
 
 // IsTranslatedC reports whether a context string is translated
 func (do *Domain) IsTranslatedC(str, ctx string) bool {
-	return do.IsTranslatedNC(str, 0, ctx)
+	return do.IsTranslatedNC(str, 1, ctx)
 }
 
 // IsTranslatedNC reports whether a plural context string is translated
@@ -440,7 +440,7 @@ func (do *Domain) IsTranslatedNC(str string, n int, ctx string) bool {
 	if !ok {
 		return false
 	}
-	return tr.IsTranslatedN(n)
+	return tr.IsTranslatedN(do.pluralForm(n))
 }
 
 // GetTranslations returns a copy of every translation in the domain. It does not support contexts.

--- a/domain_test.go
+++ b/domain_test.go
@@ -9,7 +9,7 @@ const (
 	arFixture   = "fixtures/ar/categories.po"
 )
 
-//since both Po and Mo just pass-through to Domain for MarshalBinary and UnmarshalBinary, test it here
+// since both Po and Mo just pass-through to Domain for MarshalBinary and UnmarshalBinary, test it here
 func TestBinaryEncoding(t *testing.T) {
 	// Create po objects
 	po := NewPo()
@@ -85,11 +85,11 @@ func TestDomain_IsTranslated(t *testing.T) {
 	if english.IsTranslated("Another string") {
 		t.Error("'Another string' should be reported as not translated.")
 	}
-	if !english.IsTranslatedN("Empty plural form singular", 0) {
-		t.Error("'Empty plural form singular' should be reported as translated for n=0.")
+	if !english.IsTranslatedN("Empty plural form singular", 1) {
+		t.Error("'Empty plural form singular' should be reported as translated for n=1.")
 	}
-	if english.IsTranslatedN("Empty plural form singular", 1) {
-		t.Error("'Empty plural form singular' should be reported as not translated for n=1.")
+	if english.IsTranslatedN("Empty plural form singular", 0) {
+		t.Error("'Empty plural form singular' should be reported as not translated for n=0.")
 	}
 
 	arabicPo := NewPo()
@@ -106,11 +106,8 @@ func TestDomain_IsTranslated(t *testing.T) {
 	if !arabic.IsTranslatedN("Load %d more document", 1) {
 		t.Error("Arabic plural should be reported as translated for n=1.")
 	}
-	if !arabic.IsTranslatedN("Load %d more document", 5) {
-		t.Error("Arabic plural should be reported as translated for n=5.")
-	}
-	if arabic.IsTranslatedN("Load %d more document", 6) {
-		t.Error("Arabic plural should be reported as not translated for n=6.")
+	if !arabic.IsTranslatedN("Load %d more document", 100) {
+		t.Error("Arabic plural should be reported as translated for n=100.")
 	}
 
 	// context
@@ -120,7 +117,7 @@ func TestDomain_IsTranslated(t *testing.T) {
 	if !english.IsTranslatedNC("One with var: %s", 0, "Ctx") {
 		t.Error("Context plural should be reported as translated for n=0")
 	}
-	if english.IsTranslatedNC("One with var: %s", 2, "Ctx") {
+	if !english.IsTranslatedNC("One with var: %s", 2, "Ctx") {
 		t.Error("Context plural should be reported as translated for n=2")
 	}
 }

--- a/gotext.go
+++ b/gotext.go
@@ -3,22 +3,21 @@ Package gotext implements GNU gettext utilities.
 
 For quick/simple translations you can use the package level functions directly.
 
-    import (
-	    "fmt"
-	    "github.com/leonelquinteros/gotext"
-    )
+	    import (
+		    "fmt"
+		    "github.com/leonelquinteros/gotext"
+	    )
 
-    func main() {
-        // Configure package
-        gotext.Configure("/path/to/locales/root/dir", "en_UK", "domain-name")
+	    func main() {
+	        // Configure package
+	        gotext.Configure("/path/to/locales/root/dir", "en_UK", "domain-name")
 
-        // Translate text from default domain
-        fmt.Println(gotext.Get("My text on 'domain-name' domain"))
+	        // Translate text from default domain
+	        fmt.Println(gotext.Get("My text on 'domain-name' domain"))
 
-        // Translate text from a different domain without reconfigure
-        fmt.Println(gotext.GetD("domain2", "Another text on a different domain"))
-    }
-
+	        // Translate text from a different domain without reconfigure
+	        fmt.Println(gotext.GetD("domain2", "Another text on a different domain"))
+	    }
 */
 package gotext
 
@@ -342,7 +341,7 @@ func GetNDC(dom, str, plural string, n int, ctx string, vars ...interface{}) str
 // IsTranslated reports whether a string is translated in given languages.
 // When the langs argument is omitted, the output of GetLanguages is used.
 func IsTranslated(str string, langs ...string) bool {
-	return IsTranslatedND(GetDomain(), str, 0, langs...)
+	return IsTranslatedND(GetDomain(), str, 1, langs...)
 }
 
 // IsTranslatedN reports whether a plural string is translated in given languages.
@@ -354,7 +353,7 @@ func IsTranslatedN(str string, n int, langs ...string) bool {
 // IsTranslatedD reports whether a domain string is translated in given languages.
 // When the langs argument is omitted, the output of GetLanguages is used.
 func IsTranslatedD(dom, str string, langs ...string) bool {
-	return IsTranslatedND(dom, str, 0, langs...)
+	return IsTranslatedND(dom, str, 1, langs...)
 }
 
 // IsTranslatedND reports whether a plural domain string is translated in any of given languages.
@@ -385,7 +384,7 @@ func IsTranslatedND(dom, str string, n int, langs ...string) bool {
 // IsTranslatedC reports whether a context string is translated in given languages.
 // When the langs argument is omitted, the output of GetLanguages is used.
 func IsTranslatedC(str, ctx string, langs ...string) bool {
-	return IsTranslatedNDC(GetDomain(), str, 0, ctx, langs...)
+	return IsTranslatedNDC(GetDomain(), str, 1, ctx, langs...)
 }
 
 // IsTranslatedNC reports whether a plural context string is translated in given languages.

--- a/gotext_test.go
+++ b/gotext_test.go
@@ -555,7 +555,7 @@ func TestPackageArabicTranslation(t *testing.T) {
 		t.Errorf("Expected to get '%%d selected', but got '%s'", tr)
 	}
 
-	//Plurals formula present + Plural translation string present and complete
+	// Plurals formula present + Plural translation string present and complete
 	tr = GetND("categories", "Load %d more document", "Load %d more documents", 0)
 	if tr != "حمّل %d مستندات إضافيّة" {
 		t.Errorf("Expected to get 'msgstr[0]', but got '%s'", tr)
@@ -595,4 +595,115 @@ func TestPackageArabicMissingPluralForm(t *testing.T) {
 	if tr != "الكحول والتبغ" {
 		t.Errorf("Expected to get 'الكحول والتبغ', but got '%s'", tr)
 	}
+}
+
+func BenchmarkGoText(b *testing.B) {
+
+	l := NewLocale("fixtures", "de_DE")
+	l.AddDomain("default")
+	l.SetDomain("default")
+	d := l.Domains["default"].(AppendTranslator)
+
+	b.ResetTimer()
+
+	b.Run("strings", func(b *testing.B) {
+
+		for i := 0; i < b.N; i++ {
+			tr := d.Get("My text")
+			if tr != "Translated text" {
+				b.Errorf("Expected to get 'Translated text', but got '%s'", tr)
+			}
+
+			tr = d.Get("Some random")
+			if tr != "Some random translation" {
+				b.Errorf("Expected to get 'Some random translation', but got '%s'", tr)
+			}
+
+			tr = d.Get("More")
+			if tr != "More translation" {
+				b.Errorf("Expected to get 'More translation', but got '%s'", tr)
+			}
+
+			tr = d.Get("Multi-line")
+			if tr != "Multi \nline" {
+				b.Errorf("Expected to get 'Multi \nline', but got '%s'", tr)
+			}
+
+			tr = d.Get("Another string")
+			if tr != "Another string" {
+				b.Errorf("Expected to get 'Another string', but got '%s'", tr)
+			}
+
+			tr = d.GetN("One with var: %s", "Several with vars: %s", 1, "1")
+			if tr != "This one is the singular: 1" {
+				b.Errorf("Expected to get 'This one is the singular: 1', but got '%s'", tr)
+			}
+
+			tr = d.GetN("One with var: %s", "Several with vars: %s", 2, "2")
+			if tr != "This one is the plural: 2" {
+				b.Errorf("Expected to get 'This one is the plural: 2', but got '%s'", tr)
+			}
+
+			tr = d.GetN("Empty plural form singular", "Empty plural form", 1)
+			if tr != "Singular translated" {
+				b.Errorf("Expected to get 'Singular translated', but got '%s'", tr)
+			}
+
+			tr = d.GetNC("One with var: %s", "Several with vars: %s", 1, "Ctx", "1")
+			if tr != "This one is the singular in a Ctx context: 1" {
+				b.Errorf("Expected to get This one is the singular in a Ctx context: 1', but got '%s'", tr)
+			}
+		}
+	})
+
+	p := make([]byte, 256)
+	b.Run("byte-slices", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			tr := d.Append(p[:0], "My text")
+			if string(tr) != "Translated text" {
+				b.Errorf("Expected to get 'Translated text', but got '%s'", tr)
+			}
+
+			tr = d.Append(p[:0], "Some random")
+			if string(tr) != "Some random translation" {
+				b.Errorf("Expected to get 'Some random translation', but got '%s'", tr)
+			}
+
+			tr = d.Append(p[:0], "More")
+			if string(tr) != "More translation" {
+				b.Errorf("Expected to get 'More translation', but got '%s'", tr)
+			}
+
+			tr = d.Append(p[:0], "Multi-line")
+			if string(tr) != "Multi \nline" {
+				b.Errorf("Expected to get 'Multi \nline', but got '%s'", tr)
+			}
+
+			tr = d.Append(p[:0], "Another string")
+			if string(tr) != "Another string" {
+				b.Errorf("Expected to get 'Another string', but got '%s'", tr)
+			}
+
+			tr = d.AppendN(p[:0], "One with var: %s", "Several with vars: %s", 1, "1")
+			if string(tr) != "This one is the singular: 1" {
+				b.Errorf("Expected to get 'This one is the singular: 1', but got '%s'", tr)
+			}
+
+			tr = d.AppendN(p[:0], "One with var: %s", "Several with vars: %s", 2, "2")
+			if string(tr) != "This one is the plural: 2" {
+				b.Errorf("Expected to get 'This one is the plural: 2', but got '%s'", tr)
+			}
+
+			tr = d.AppendN(p[:0], "Empty plural form singular", "Empty plural form", 1)
+			if string(tr) != "Singular translated" {
+				b.Errorf("Expected to get 'Singular translated', but got '%s'", tr)
+			}
+
+			tr = d.AppendNC(p[:0], "One with var: %s", "Several with vars: %s", 1, "Ctx", "1")
+			if string(tr) != "This one is the singular in a Ctx context: 1" {
+				b.Errorf("Expected to get This one is the singular in a Ctx context: 1', but got '%s'", tr)
+			}
+		}
+	})
+
 }

--- a/helper.go
+++ b/helper.go
@@ -37,6 +37,15 @@ func Printf(str string, vars ...interface{}) string {
 	return str
 }
 
+// Appendf applies text formatting only when needed to parse variables.
+func Appendf(b []byte, str string, vars ...interface{}) []byte {
+	if len(vars) > 0 {
+		return fmt.Appendf(b, str, vars...)
+	}
+
+	return append(b, str...)
+}
+
 // NPrintf support named format
 // NPrintf("%(name)s is Type %(type)s", map[string]interface{}{"name": "Gotext", "type": "struct"})
 func NPrintf(format string, params map[string]interface{}) {
@@ -45,7 +54,8 @@ func NPrintf(format string, params map[string]interface{}) {
 }
 
 // Sprintf support named format
-//      Sprintf("%(name)s is Type %(type)s", map[string]interface{}{"name": "Gotext", "type": "struct"})
+//
+//	Sprintf("%(name)s is Type %(type)s", map[string]interface{}{"name": "Gotext", "type": "struct"})
 func Sprintf(format string, params map[string]interface{}) string {
 	f, p := parseSprintf(format, params)
 	return fmt.Sprintf(f, p...)

--- a/mo.go
+++ b/mo.go
@@ -45,10 +45,9 @@ Example:
 		// Get Translation
 		fmt.Println(mo.Get("Translate this"))
 	}
-
 */
 type Mo struct {
-	//these three public members are for backwards compatibility. they are just set to the value in the domain
+	// these three public members are for backwards compatibility. they are just set to the value in the domain
 	Headers     HeaderMap
 	Language    string
 	PluralForms string
@@ -56,7 +55,7 @@ type Mo struct {
 	fs          fs.FS
 }
 
-//NewMo should always be used to instantiate a new Mo object
+// NewMo should always be used to instantiate a new Mo object
 func NewMo() *Mo {
 	mo := new(Mo)
 	mo.domain = NewDomain()
@@ -75,21 +74,33 @@ func (mo *Mo) GetDomain() *Domain {
 	return mo.domain
 }
 
-//all of the Get functions are for convenience and aid in backwards compatibility
+// all of the Get functions are for convenience and aid in backwards compatibility
 func (mo *Mo) Get(str string, vars ...interface{}) string {
 	return mo.domain.Get(str, vars...)
+}
+func (mo *Mo) Append(b []byte, str string, vars ...interface{}) []byte {
+	return mo.domain.Append(b, str, vars...)
 }
 
 func (mo *Mo) GetN(str, plural string, n int, vars ...interface{}) string {
 	return mo.domain.GetN(str, plural, n, vars...)
 }
+func (mo *Mo) AppendN(b []byte, str, plural string, n int, vars ...interface{}) []byte {
+	return mo.domain.AppendN(b, str, plural, n, vars...)
+}
 
 func (mo *Mo) GetC(str, ctx string, vars ...interface{}) string {
 	return mo.domain.GetC(str, ctx, vars...)
 }
+func (mo *Mo) AppendC(b []byte, str, ctx string, vars ...interface{}) []byte {
+	return mo.domain.AppendC(b, str, ctx, vars...)
+}
 
 func (mo *Mo) GetNC(str, plural string, n int, ctx string, vars ...interface{}) string {
 	return mo.domain.GetNC(str, plural, n, ctx, vars...)
+}
+func (mo *Mo) AppendNC(b []byte, str, plural string, n int, ctx string, vars ...interface{}) []byte {
+	return mo.domain.AppendNC(b, str, plural, n, ctx, vars...)
 }
 
 func (mo *Mo) IsTranslated(str string) bool {

--- a/po.go
+++ b/po.go
@@ -85,6 +85,10 @@ func (po *Po) GetRefs(str string) []string {
 	return po.domain.GetRefs(str)
 }
 
+func (po *Po) SetPluralResolver(f func(int) int) {
+	po.domain.customPluralResolver = f
+}
+
 func (po *Po) Set(id, str string) {
 	po.domain.Set(id, str)
 }

--- a/po.go
+++ b/po.go
@@ -33,10 +33,9 @@ Example:
 		// Get Translation
 		fmt.Println(po.Get("Translate this"))
 	}
-
 */
 type Po struct {
-	//these three public members are for backwards compatibility. they are just set to the value in the domain
+	// these three public members are for backwards compatibility. they are just set to the value in the domain
 	Headers     HeaderMap
 	Language    string
 	PluralForms string
@@ -55,7 +54,7 @@ const (
 	msgStr
 )
 
-//NewPo should always be used to instantiate a new Po object
+// NewPo should always be used to instantiate a new Po object
 func NewPo() *Po {
 	po := new(Po)
 	po.domain = NewDomain()
@@ -92,12 +91,18 @@ func (po *Po) Set(id, str string) {
 func (po *Po) Get(str string, vars ...interface{}) string {
 	return po.domain.Get(str, vars...)
 }
+func (po *Po) Append(b []byte, str string, vars ...interface{}) []byte {
+	return po.domain.Append(b, str, vars...)
+}
 
 func (po *Po) SetN(id, plural string, n int, str string) {
 	po.domain.SetN(id, plural, n, str)
 }
 func (po *Po) GetN(str, plural string, n int, vars ...interface{}) string {
 	return po.domain.GetN(str, plural, n, vars...)
+}
+func (po *Po) AppendN(b []byte, str, plural string, n int, vars ...interface{}) []byte {
+	return po.domain.AppendN(b, str, plural, n, vars...)
 }
 
 func (po *Po) SetC(id, ctx, str string) {
@@ -106,12 +111,18 @@ func (po *Po) SetC(id, ctx, str string) {
 func (po *Po) GetC(str, ctx string, vars ...interface{}) string {
 	return po.domain.GetC(str, ctx, vars...)
 }
+func (po *Po) AppendC(b []byte, str, ctx string, vars ...interface{}) []byte {
+	return po.domain.AppendC(b, str, ctx, vars...)
+}
 
 func (po *Po) SetNC(id, plural, ctx string, n int, str string) {
 	po.domain.SetNC(id, plural, ctx, n, str)
 }
 func (po *Po) GetNC(str, plural string, n int, ctx string, vars ...interface{}) string {
 	return po.domain.GetNC(str, plural, n, ctx, vars...)
+}
+func (po *Po) AppendNC(b []byte, str, plural string, n int, ctx string, vars ...interface{}) []byte {
+	return po.domain.AppendNC(b, str, plural, n, ctx, vars...)
 }
 
 func (po *Po) IsTranslated(str string) bool {

--- a/translator.go
+++ b/translator.go
@@ -27,6 +27,13 @@ type Translator interface {
 	UnmarshalBinary([]byte) error
 	GetDomain() *Domain
 }
+type AppendTranslator interface {
+	Translator
+	Append(b []byte, str string, vars ...interface{}) []byte
+	AppendN(b []byte, str, plural string, n int, vars ...interface{}) []byte
+	AppendC(b []byte, str, ctx string, vars ...interface{}) []byte
+	AppendNC(b []byte, str, plural string, n int, ctx string, vars ...interface{}) []byte
+}
 
 // TranslatorEncoding is used as intermediary storage to encode Translator objects to Gob.
 type TranslatorEncoding struct {
@@ -66,7 +73,7 @@ func (te *TranslatorEncoding) GetTranslator() Translator {
 	return po
 }
 
-//getFileData reads a file and returns the byte slice after doing some basic sanity checking
+// getFileData reads a file and returns the byte slice after doing some basic sanity checking
 func getFileData(f string, filesystem fs.FS) ([]byte, error) {
 	if filesystem != nil {
 		return fs.ReadFile(filesystem, f)


### PR DESCRIPTION
I believe this was discussed and accepted in #92 but that PR apparently had some issues and was never merged. I independently encountered and fixed the same bug, so here's another PR that should merge cleanly. Appreciate the great library.

