### PR TITLE
go embed fs with path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/leonelquinteros/gotext
 
-// go: no requirements found in Gopkg.lock
-
 require golang.org/x/tools v0.1.12
 
-go 1.13
+go 1.16

--- a/locale.go
+++ b/locale.go
@@ -21,30 +21,29 @@ multiple languages at the same time by working with this object.
 
 Example:
 
-    import (
-	"encoding/gob"
-	"bytes"
-	    "fmt"
-	    "github.com/leonelquinteros/gotext"
-    )
+	    import (
+		"encoding/gob"
+		"bytes"
+		    "fmt"
+		    "github.com/leonelquinteros/gotext"
+	    )
 
-    func main() {
-        // Create Locale with library path and language code
-        l := gotext.NewLocale("/path/to/i18n/dir", "en_US")
+	    func main() {
+	        // Create Locale with library path and language code
+	        l := gotext.NewLocale("/path/to/i18n/dir", "en_US")
 
-        // Load domain '/path/to/i18n/dir/en_US/LC_MESSAGES/default.{po,mo}'
-        l.AddDomain("default")
+	        // Load domain '/path/to/i18n/dir/en_US/LC_MESSAGES/default.{po,mo}'
+	        l.AddDomain("default")
 
-        // Translate text from default domain
-        fmt.Println(l.Get("Translate this"))
+	        // Translate text from default domain
+	        fmt.Println(l.Get("Translate this"))
 
-        // Load different domain ('/path/to/i18n/dir/en_US/LC_MESSAGES/extras.{po,mo}')
-        l.AddDomain("extras")
+	        // Load different domain ('/path/to/i18n/dir/en_US/LC_MESSAGES/extras.{po,mo}')
+	        l.AddDomain("extras")
 
-        // Translate text from domain
-        fmt.Println(l.GetD("extras", "Translate this"))
-    }
-
+	        // Translate text from domain
+	        fmt.Println(l.GetD("extras", "Translate this"))
+	    }
 */
 type Locale struct {
 	// Path to locale files.
@@ -80,6 +79,14 @@ func NewLocale(p, l string) *Locale {
 func NewLocaleFS(l string, filesystem fs.FS) *Locale {
 	loc := NewLocale("", l)
 	loc.fs = filesystem
+	return loc
+}
+
+// NewLocaleFSWithPath returns a Locale working with a fs.FS on a p path folder.
+func NewLocaleFSWithPath(l string, filesystem fs.FS, p string) *Locale {
+	loc := NewLocale("", l)
+	loc.fs = filesystem
+	loc.path = p
 	return loc
 }
 
@@ -333,7 +340,7 @@ func (l *Locale) GetNDC(dom, str, plural string, n int, ctx string, vars ...inte
 	return Printf(plural, vars...)
 }
 
-//GetTranslations returns a copy of all translations in all domains of this locale. It does not support contexts.
+// GetTranslations returns a copy of all translations in all domains of this locale. It does not support contexts.
 func (l *Locale) GetTranslations() map[string]*Translation {
 	all := make(map[string]*Translation)
 

--- a/locale_test.go
+++ b/locale_test.go
@@ -6,6 +6,7 @@
 package gotext
 
 import (
+	"embed"
 	"os"
 	"path"
 	"testing"
@@ -703,6 +704,9 @@ func TestLocaleBinaryEncoding(t *testing.T) {
 	}
 }
 
+//go:embed fixtures
+var localeFS embed.FS
+
 func TestLocale_GetTranslations(t *testing.T) {
 	var locales []*Locale
 	{ // test os
@@ -710,6 +714,9 @@ func TestLocale_GetTranslations(t *testing.T) {
 	}
 	{ // test fs
 		locales = append(locales, NewLocaleFS("en_US", os.DirFS("fixtures")))
+	}
+	{ // test embed
+		locales = append(locales, NewLocaleFSWithPath("en_US", localeFS, "fixtures"))
 	}
 
 	for _, l := range locales {


### PR DESCRIPTION
# Before creating your Pull Request...

Go embed FS are 

- New Pull Requests should include a good description of what's being merged. 
- Ideally, all Pull Requests are preceded by a discussion initiated in an Issue on this repository. 
- For bug fixes is mandatory to have tests that cover and fail when the bug is present and will pass after this Pull Request.
- For changes and improvements, new tests have to be provided to cover the new features.


## Is this a fix, improvement or something else?

yes, 

## What does this change implement/fix?

- allows to use go embed by adding a backwards compatible `NewLocaleFSWithPath` function, 
- adds tests for a embed.FS, addressing #68  
- bumps go version to 1.16 which is the minimum required to use embed package

Bumping go version can be troublesome for existing users, although embed.FS tests will not be supported. It is possible to keep 1.13 compatibility by removing the additional unit test case.

Either way, in order to use embed.FS path seems to be required.

## I have ...

- [X] answered the 2 questions above,
- [X] discussed this change in an issue, #97
- [X] included tests to cover this changes.
