### PR TITLE
Fixed quote escaping issues in PO file formatting

### DIFF
--- a/cli/xgotext/parser/dir/golang.go
+++ b/cli/xgotext/parser/dir/golang.go
@@ -24,17 +24,7 @@ type GetterDef struct {
 
 // maxArgIndex returns the largest argument index
 func (d *GetterDef) maxArgIndex() int {
-	m := d.Id
-	if d.Plural > m {
-		m = d.Plural
-	}
-	if d.Context > m {
-		m = d.Context
-	}
-	if d.Domain > m {
-		m = d.Domain
-	}
-	return m
+	return max(d.Id, d.Plural, d.Context, d.Domain)
 }
 
 // list of supported getter


### PR DESCRIPTION
## Is this a fix, improvement or something else?

Fix

---

## What does this change implement/fix?

Fixes quote and backslash escaping in PO file generation. The previous implementation couldn't properly handle strings with quotes or special characters, causing syntax errors in the generated files. Replaced string splitting with character-by-character processing to correctly escape all special characters and handle multiline strings properly.

---

## I have ...

- [x] answered the 2 questions above,
- [ ] discussed this change in an issue,
- [ ] included tests to cover this changes.

It didn't even have its own tests before, in the first place -_-
