### PR TITLE
add GetCtxTranslations() to domain

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -555,6 +555,39 @@ func (do *Domain) GetTranslations() map[string]*Translation {
 	return all
 }
 
+//GetCtxTranslations returns a copy of every translation in the domain with context
+func (do *Domain) GetCtxTranslations() map[string]map[string]*Translation {
+	all := make(map[string]map[string]*Translation, len(do.contextTranslations))
+
+	do.trMutex.RLock()
+	defer do.trMutex.RUnlock()
+
+	for ctx, translations := range do.contextTranslations {
+		for msgID, trans := range translations {
+			newTrans := NewTranslation()
+			newTrans.ID = trans.ID
+			newTrans.PluralID = trans.PluralID
+			newTrans.dirty = trans.dirty
+			if len(trans.Refs) > 0 {
+				newTrans.Refs = make([]string, len(trans.Refs))
+				copy(newTrans.Refs, trans.Refs)
+			}
+			for k, v := range trans.Trs {
+				newTrans.Trs[k] = v
+			}
+
+			if all[ctx] == nil {
+				all[ctx] = make(map[string]*Translation)
+			}
+
+			all[ctx][msgID] = newTrans
+		}
+
+	}
+
+	return all
+}
+
 type SourceReference struct {
 	path    string
 	line    int

--- a/domain_test.go
+++ b/domain_test.go
@@ -73,6 +73,46 @@ func TestDomain_GetTranslations(t *testing.T) {
 	}
 }
 
+func TestDomain_GetCtxTranslations(t *testing.T) {
+	po := NewPo()
+	po.ParseFile(enUSFixture)
+
+	domain := po.GetDomain()
+	all := domain.GetCtxTranslations()
+
+	if len(all) != len(domain.contextTranslations) {
+		t.Error("lengths should match")
+	}
+
+	if domain.contextTranslations["Ctx"] == nil {
+		t.Error("Context 'Ctx' should exist")
+	}
+
+	for k, v := range domain.contextTranslations {
+		for kk, vv := range v {
+			if all[k][kk] == vv {
+				t.Error("GetCtxTranslations should be returning a copy, but pointers are equal")
+			}
+			if all[k][kk].ID != vv.ID {
+				t.Error("IDs should match")
+			}
+			if all[k][kk].PluralID != vv.PluralID {
+				t.Error("PluralIDs should match")
+			}
+			if all[k][kk].dirty != vv.dirty {
+				t.Error("dirty flag should match")
+			}
+			if len(all[k][kk].Trs) != len(vv.Trs) {
+				t.Errorf("Trs length does not match: %d != %d", len(all[k][kk].Trs), len(vv.Trs))
+			}
+			if len(all[k][kk].Refs) != len(vv.Refs) {
+				t.Errorf("Refs length does not match: %d != %d", len(all[k][kk].Refs), len(vv.Refs))
+			}
+		}
+
+	}
+}
+
 func TestDomain_IsTranslated(t *testing.T) {
 	englishPo := NewPo()
 	englishPo.ParseFile(enUSFixture)


### PR DESCRIPTION
# Before creating your Pull Request...

this add `GetCtxTranslations()` to domain to expose the translations in context just like `GetTranslations()` does without context


## Is this a fix, improvement or something else?

improvement

...


## What does this change implement/fix?

it adds the possibility to retrieve to context translation keys
... 


## I have ...

- [x] answered the 2 questions above,
- [ ] discussed this change in an issue,
- [x] included tests to cover this changes.
