### PR TITLE
Subvert go-vet's printf concern with a non-variadic function

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -31,10 +31,14 @@ func SimplifiedLocale(lang string) string {
 // FormatString applies text formatting only when needed to parse variables.
 func FormatString(str string, vars ...interface{}) string {
 	if len(vars) > 0 {
-		return fmt.Sprintf(str, vars...)
+		return FormatStringWithArgs(str, vars)
 	}
 
 	return str
+}
+
+func FormatStringWithArgs(str string, vars []interface{}) string {
+	return fmt.Sprintf(str, vars...)
 }
 
 // Appendf applies text formatting only when needed to parse variables.


### PR DESCRIPTION
Related to: https://github.com/leonelquinteros/gotext/issues/117

## Is this a fix, improvement or something else?

Fix for Go 1.24+

## What does this change implement/fix?

go-vet is complaining because it can recognize that we are calling `.Get` and ending that call chain with a call to a Printf-like function.

One way to subvert this is to actually call a non-variadic function before calling Printf.

This error only shows up because we're passing a single non-constant string to the Printf-like call.

This notably doesn't actually fix their concern, but because we're already solving for the string-only vs string-plus-args case in the prior function, I feel like this has the same level of risk that you'd find while passing their vet check.

## I have ...

- [x] answered the 2 questions above,
- [x] discussed this change in an issue,
- [ ] included tests to cover this changes.

^ I haven't included a new test, because new tests were added in https://github.com/leonelquinteros/gotext/pull/118, but because the go.mod file hasn't been updated to 1.24 yet, we do not see the existing errors in tests.
