### PR TITLE
feat: allow to customise import path

### DIFF
--- a/cli/xgotext/main.go
+++ b/cli/xgotext/main.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	pkgTree       = flag.String("pkg-tree", "", "main path: /path/to/go/pkg")
+	importPath    = flag.String("import-path", "github.com/leonelquinteros/gotext", "import path: foo.org/myproject/i18n")
 	dirName       = flag.String("in", "", "input dir: /path/to/go/pkg")
 	outputDir     = flag.String("out", "", "output dir: /path/to/i18n/files")
 	defaultDomain = flag.String("default", "default", "Name of default domain")
@@ -40,12 +41,12 @@ func main() {
 	}
 
 	if *pkgTree != "" {
-		err := pkg_tree.ParsePkgTree(*pkgTree, data, *verbose)
+		err := pkg_tree.ParsePkgTree(*pkgTree, *importPath, data, *verbose)
 		if err != nil {
 			log.Fatal(err)
 		}
 	} else {
-		err := dir.ParseDirRec(*dirName, strings.Split(*excludeDirs, ","), data, *verbose)
+		err := dir.ParseDirRec(*dirName, *importPath, strings.Split(*excludeDirs, ","), data, *verbose)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cli/xgotext/parser/dir/golang.go
+++ b/cli/xgotext/parser/dir/golang.go
@@ -17,7 +17,7 @@ func init() {
 }
 
 // parse go package
-func goParser(dirPath, basePath string, data *parser.DomainMap) error {
+func goParser(dirPath, basePath, importPath string, data *parser.DomainMap) error {
 	fileSet := token.NewFileSet()
 
 	conf := packages.Config{
@@ -54,6 +54,7 @@ func goParser(dirPath, basePath string, data *parser.DomainMap) error {
 				ImportedPackages: map[string]*packages.Package{
 					pkgs[0].Name: pkgs[0],
 				},
+				ImportPath: importPath,
 			},
 		}
 

--- a/cli/xgotext/parser/dir/parser.go
+++ b/cli/xgotext/parser/dir/parser.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ParseDirFunc parses one directory
-type ParseDirFunc func(filePath, basePath string, data *parser.DomainMap) error
+type ParseDirFunc func(filePath, basePath, importPath string, data *parser.DomainMap) error
 
 var knownParser []ParseDirFunc
 
@@ -24,12 +24,12 @@ func AddParser(parser ParseDirFunc) {
 }
 
 // ParseDir calls all known parser for each directory
-func ParseDir(dirPath, basePath string, data *parser.DomainMap) error {
+func ParseDir(dirPath, basePath, importPath string, data *parser.DomainMap) error {
 	dirPath, _ = filepath.Abs(dirPath)
 	basePath, _ = filepath.Abs(basePath)
 
 	for _, parser := range knownParser {
-		err := parser(dirPath, basePath, data)
+		err := parser(dirPath, basePath, importPath, data)
 		if err != nil {
 			return err
 		}
@@ -38,7 +38,7 @@ func ParseDir(dirPath, basePath string, data *parser.DomainMap) error {
 }
 
 // ParseDirRec calls all known parser for each directory
-func ParseDirRec(dirPath string, exclude []string, data *parser.DomainMap, verbose bool) error {
+func ParseDirRec(dirPath, importPath string, exclude []string, data *parser.DomainMap, verbose bool) error {
 	dirPath, _ = filepath.Abs(dirPath)
 
 	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
@@ -58,7 +58,7 @@ func ParseDirRec(dirPath string, exclude []string, data *parser.DomainMap, verbo
 				log.Print(path)
 			}
 
-			err := ParseDir(path, dirPath, data)
+			err := ParseDir(path, dirPath, importPath, data)
 			if err != nil {
 				return err
 			}

--- a/cli/xgotext/parser/gofile.go
+++ b/cli/xgotext/parser/gofile.go
@@ -47,6 +47,7 @@ type GoFile struct {
 	PkgConf *packages.Config
 
 	ImportedPackages map[string]*packages.Package
+	ImportPath       string
 }
 
 // GetType from ident object
@@ -69,7 +70,7 @@ func (g *GoFile) CheckType(rawType types.Type) bool {
 		return g.CheckType(t.Elem())
 
 	case *types.Named:
-		if t.Obj().Pkg() == nil || t.Obj().Pkg().Path() != "github.com/leonelquinteros/gotext" {
+		if t.Obj().Pkg() == nil || t.Obj().Pkg().Path() != g.ImportPath {
 			return false
 		}
 
@@ -96,7 +97,7 @@ func (g *GoFile) InspectCallExpr(n *ast.CallExpr) {
 		// object is a package if the Obj is not set
 		if e.Obj == nil {
 			pkg, ok := g.ImportedPackages[e.Name]
-			if !ok || pkg.PkgPath != "github.com/leonelquinteros/gotext" {
+			if !ok || pkg.PkgPath != g.ImportPath {
 				return
 			}
 

--- a/cli/xgotext/parser/pkg-tree/golang.go
+++ b/cli/xgotext/parser/pkg-tree/golang.go
@@ -14,21 +14,21 @@ import (
 )
 
 // ParsePkgTree parse go package tree
-func ParsePkgTree(pkgPath string, data *parser.DomainMap, verbose bool) error {
+func ParsePkgTree(pkgPath, importPath string, data *parser.DomainMap, verbose bool) error {
 	basePath, err := os.Getwd()
 	if err != nil {
 		log.Fatal(err)
 	}
-	return pkgParser(pkgPath, basePath, data, verbose)
+	return pkgParser(pkgPath, basePath, importPath, data, verbose)
 }
 
-func pkgParser(dirPath, basePath string, data *parser.DomainMap, verbose bool) error {
+func pkgParser(dirPath, basePath, importPath string, data *parser.DomainMap, verbose bool) error {
 	mainPkg, err := loadPackage(dirPath)
 	if err != nil {
 		return err
 	}
 
-	for _, pkg := range filterPkgs(mainPkg) {
+	for _, pkg := range filterPkgs(mainPkg, importPath) {
 		if verbose {
 			fmt.Println(pkg.ID)
 		}
@@ -76,22 +76,22 @@ func loadPackage(name string) (*packages.Package, error) {
 	return pkgs[0], nil
 }
 
-func filterPkgs(pkg *packages.Package) []*packages.Package {
-	result := filterPkgsRec(pkg)
+func filterPkgs(pkg *packages.Package, importPath string) []*packages.Package {
+	result := filterPkgsRec(pkg, importPath)
 	return result
 }
 
-func filterPkgsRec(pkg *packages.Package) []*packages.Package {
+func filterPkgsRec(pkg *packages.Package, importPath string) []*packages.Package {
 	result := make([]*packages.Package, 0, 100)
 	pkgCache[pkg.ID] = pkg
 	for _, importedPkg := range pkg.Imports {
-		if importedPkg.ID == "github.com/leonelquinteros/gotext" {
+		if importedPkg.ID == importPath {
 			result = append(result, pkg)
 		}
 		if _, ok := pkgCache[importedPkg.ID]; ok {
 			continue
 		}
-		result = append(result, filterPkgsRec(importedPkg)...)
+		result = append(result, filterPkgsRec(importedPkg, importPath)...)
 	}
 	return result
 }


### PR DESCRIPTION
## Is this a fix, improvement or something else?

Improvement. Related to https://github.com/leonelquinteros/gotext/issues/124.

```
  -import-path string
        import path: foo.org/myproject/i18n (default "github.com/leonelquinteros/gotext")
```

## What does this change implement/fix?

A short-cut towards allowing users of `xgotext` to customise the location of where their i10n function gets called from. 

I was able to understand how to do this instead of an actualy full-blown `--keyword` argument, pending https://github.com/leonelquinteros/gotext/issues/124#issuecomment-3211589971.

I don't think this is a good solution but you can now override the import path and then re-define a `Get` / `GetC` / etc. in your own project.

Maybe some people prefer this approach, I'm not sure.

## I have ...

- [x] answered the 2 questions above,
- [ ] discussed this change in an issue,
- [ ] included tests to cover this changes.
