### PR TITLE
Extend dictionary generator to support go-format flag

### DIFF
--- a/cli/xgotext/parser/domain.go
+++ b/cli/xgotext/parser/domain.go
@@ -14,6 +14,7 @@ type Translation struct {
 	MsgIDPlural     string
 	Context         string
 	SourceLocations []string
+	Flags           []string
 }
 
 // AddLocations to translation
@@ -33,6 +34,10 @@ func (t *Translation) Dump() string {
 	sort.Strings(locations)
 	for _, location := range locations {
 		data = append(data, "#: "+location)
+	}
+
+	for _, flag := range t.Flags {
+		data = append(data, "#, "+flag)
 	}
 
 	if t.Context != "" {

--- a/cli/xgotext/parser/gofile.go
+++ b/cli/xgotext/parser/gofile.go
@@ -25,6 +25,15 @@ func (d *GetterDef) MaxArgIndex() int {
 	return max(d.ID, d.Plural, d.Context, d.Domain)
 }
 
+// OptionalVarsIndex returns the index of the first optioal message variable
+// argument.
+func (d *GetterDef) OptionalVarsIndex() int {
+	// Plural string argument is allways followed by plural form number `n`
+	// argument. Most of the time it is next parameter after max index, but
+	// if our max index is d.Plural we need to account for the extra `n`.
+	return max(d.MaxArgIndex()+1, d.Plural+2)
+}
+
 // list of supported getter
 var gotextGetter = map[string]GetterDef{
 	"Get":    {0, -1, -1, -1},
@@ -177,6 +186,9 @@ func (g *GoFile) ParseGetter(def GetterDef, args []*ast.BasicLit, pos string) {
 			return
 		}
 		trans.Context = args[def.Context].Value
+	}
+	if len(args) > def.OptionalVarsIndex() {
+		trans.Flags = append(trans.Flags, "go-format")
 	}
 
 	g.Data.AddTranslation(domain, &trans)

--- a/cli/xgotext/parser/pkg-tree/golang_test.go
+++ b/cli/xgotext/parser/pkg-tree/golang_test.go
@@ -1,8 +1,10 @@
 package pkgtree
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/leonelquinteros/gotext/cli/xgotext/parser"
@@ -44,4 +46,32 @@ EOL`, "multline\nending with EOL\n", "type alias",
 			t.Errorf("translation '%v' not in result", tr)
 		}
 	}
+}
+
+func TestFormatTag(t *testing.T) {
+	defaultDomain := "default"
+	data := &parser.DomainMap{
+		Default: defaultDomain,
+	}
+	pkgPath := "testdata/format"
+	err := ParsePkgTree(pkgPath, data, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for domain, translations := range data.Domains {
+		dumpFile := filepath.Join(pkgPath, fmt.Sprintf("%s.po", domain))
+		expectedBytes, err := os.ReadFile(dumpFile)
+		if err != nil {
+			t.Fatalf("reading %q: %s", dumpFile, err)
+		}
+		expected := strings.TrimSpace(string(expectedBytes))
+		actual := translations.Dump()
+		if expected != actual {
+			t.Logf("want:\n%s", expected)
+			t.Logf("got:\n%s", actual)
+			t.Errorf("domain %q dump does match", domain)
+		}
+	}
+
 }

--- a/cli/xgotext/parser/pkg-tree/testdata/format/default.po
+++ b/cli/xgotext/parser/pkg-tree/testdata/format/default.po
@@ -1,0 +1,48 @@
+#: testdata/format/main.go:21
+msgid "simple"
+msgstr ""
+
+#: testdata/format/main.go:11
+#, go-format
+msgid "simple %s"
+msgstr ""
+
+#: testdata/format/main.go:25
+msgid "singular"
+msgid_plural "plural"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testdata/format/main.go:15
+#, go-format
+msgid "singular %s"
+msgid_plural "plural %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testdata/format/main.go:23
+msgctxt "ctx"
+msgid "simple"
+msgstr ""
+
+#: testdata/format/main.go:13
+#, go-format
+msgctxt "ctx"
+msgid "simple %s"
+msgstr ""
+
+#: testdata/format/main.go:27
+msgctxt "ctx"
+msgid "singular"
+msgid_plural "plural"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testdata/format/main.go:17
+#, go-format
+msgctxt "ctx"
+msgid "singular %s"
+msgid_plural "plural %s"
+msgstr[0] ""
+msgstr[1] ""
+

--- a/cli/xgotext/parser/pkg-tree/testdata/format/domain.po
+++ b/cli/xgotext/parser/pkg-tree/testdata/format/domain.po
@@ -1,0 +1,47 @@
+#: testdata/format/main.go:22
+msgid "simple"
+msgstr ""
+
+#: testdata/format/main.go:12
+#, go-format
+msgid "simple %s"
+msgstr ""
+
+#: testdata/format/main.go:26
+msgid "singular"
+msgid_plural "plural"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testdata/format/main.go:16
+#, go-format
+msgid "singular %s"
+msgid_plural "plural %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testdata/format/main.go:24
+msgctxt "ctx"
+msgid "simple"
+msgstr ""
+
+#: testdata/format/main.go:14
+#, go-format
+msgctxt "ctx"
+msgid "simple %s"
+msgstr ""
+
+#: testdata/format/main.go:28
+msgctxt "ctx"
+msgid "singular"
+msgid_plural "plural"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testdata/format/main.go:18
+#, go-format
+msgctxt "ctx"
+msgid "singular %s"
+msgid_plural "plural %s"
+msgstr[0] ""
+msgstr[1] ""

--- a/cli/xgotext/parser/pkg-tree/testdata/format/main.go
+++ b/cli/xgotext/parser/pkg-tree/testdata/format/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/leonelquinteros/gotext"
+)
+
+func main() {
+	// with format arguments
+	fmt.Println(gotext.Get("simple %s", "param"))
+	fmt.Println(gotext.GetD("domain", "simple %s", "param"))
+	fmt.Println(gotext.GetC("simple %s", "ctx", "param"))
+	fmt.Println(gotext.GetDC("domain", "simple %s", "ctx", "param"))
+	fmt.Println(gotext.GetN("singular %s", "plural %s", 2, "param"))
+	fmt.Println(gotext.GetND("domain", "singular %s", "plural %s", 2, "param"))
+	fmt.Println(gotext.GetNC("singular %s", "plural %s", 2, "ctx", "param"))
+	fmt.Println(gotext.GetNDC("domain", "singular %s", "plural %s", 2, "ctx", "param"))
+
+	// without format arguments
+	fmt.Println(gotext.Get("simple"))
+	fmt.Println(gotext.GetD("domain", "simple"))
+	fmt.Println(gotext.GetC("simple", "ctx"))
+	fmt.Println(gotext.GetDC("domain", "simple", "ctx"))
+	fmt.Println(gotext.GetN("singular", "plural", 2))
+	fmt.Println(gotext.GetND("domain", "singular", "plural", 2))
+	fmt.Println(gotext.GetNC("singular", "plural", 2, "ctx"))
+	fmt.Println(gotext.GetNDC("domain", "singular", "plural", 2, "ctx"))
+
+}


### PR DESCRIPTION
This commit extends the dictionary generator to add `go-format` gettext flag to the translation entries, that uses printf style parameter interpolation.

The `go-format` flag is a hint for translation management software to add extra checks for the translations. For example, making sure translated string still has all the parameter placeholders.

Flag syntax - https://www.gnu.org/software/gettext/manual/html_node/PO-File-Entries.html

Supported sticky flags - https://www.gnu.org/software/gettext/manual/html_node/Sticky-flags.html