### PR TITLE
feat:xgotext support string variables and const

### DIFF
--- a/cli/xgotext/fixtures/main.go
+++ b/cli/xgotext/fixtures/main.go
@@ -13,6 +13,14 @@ import (
 type Fake struct {
 }
 
+const (
+	ConstantTesting = "this is constant testing"
+)
+
+var (
+	variableTesting = "this is variable testing"
+)
+
 // Get by id
 func (f Fake) Get(id int) int {
 	return 42
@@ -38,6 +46,12 @@ var NL = func() *gotext.Locale {
 func main() {
 	// Configure package
 	gotext.Configure("/path/to/locales/root/dir", "en_UK", "domain-name")
+
+	// constant testing
+	fmt.Println(gotext.Get(ConstantTesting))
+
+	// variable testing
+	fmt.Println(gotext.Get(variableTesting))
 
 	// Translate text from default domain
 	fmt.Println(gotext.Get("My text on 'domain-name' domain"))

--- a/cli/xgotext/parser/pkg-tree/golang_test.go
+++ b/cli/xgotext/parser/pkg-tree/golang_test.go
@@ -34,6 +34,9 @@ line
 string
 ending with
 EOL`, "multline\nending with EOL\n", "type alias",
+		"this is constant testing",
+		"this is variable testing",
+		"some string to translate",
 	}
 
 	if len(translations) != len(data.Domains[defaultDomain].Translations) {


### PR DESCRIPTION
## improvement

xgotext support string variables and const
Although it supports direct translation, I might want to reuse the text just by calling variables


## What does this change implement/fix?
const testStr = "testStrVal"
str := "strValue"

fmt.Println(gotext.Get(testStr))
fmt.Println(gotext.Get(str))

