### PR TITLE
Fix: Support xgotext extraction from chained calls

### DIFF
--- a/cli/xgotext/fixtures/main.go
+++ b/cli/xgotext/fixtures/main.go
@@ -115,6 +115,22 @@ EOL`))
 
 	// Locale constructor call
 	NL().Get("locale constructor call")
+
+	// Even more complex chains
+	gotext.NewLocale("/path", "en").Get("chained locale")
+	gotext.NewPo().Get("chained po")
+}
+
+// GetTranslator returns a Translator
+func GetTranslator() gotext.Translator {
+	return gotext.NewPo()
+}
+
+func complexChains() {
+	GetTranslator().Get("chained from func")
+
+	var tr gotext.Translator = gotext.NewPo()
+	tr.Get("from interface")
 }
 
 // dummy function

--- a/cli/xgotext/fixtures/main.go
+++ b/cli/xgotext/fixtures/main.go
@@ -119,6 +119,8 @@ EOL`))
 	// Even more complex chains
 	gotext.NewLocale("/path", "en").Get("chained locale")
 	gotext.NewPo().Get("chained po")
+
+	complexChains()
 }
 
 // GetTranslator returns a Translator

--- a/cli/xgotext/parser/gofile.go
+++ b/cli/xgotext/parser/gofile.go
@@ -95,8 +95,8 @@ func (g *GoFile) CheckType(rawType types.Type) bool {
 
 	case *types.Interface:
 		// Check if it's the Translator interface from our package
-		// This is a bit more complex, but usually it's wrapped in a Named type
-		return false
+		// This is used for interfaces like 'Translator'
+		return t.NumMethods() > 0 && t.Method(0).Pkg() != nil && t.Method(0).Pkg().Path() == "github.com/leonelquinteros/gotext"
 
 	default:
 		return false

--- a/cli/xgotext/parser/gofile.go
+++ b/cli/xgotext/parser/gofile.go
@@ -52,7 +52,7 @@ type GoFile struct {
 // GetType from ident object
 func (g *GoFile) GetType(ident *ast.Ident) types.Object {
 	for _, pkg := range g.ImportedPackages {
-		if pkg.Types == nil {
+		if pkg.TypesInfo == nil {
 			continue
 		}
 		if obj, ok := pkg.TypesInfo.Uses[ident]; ok {
@@ -62,8 +62,25 @@ func (g *GoFile) GetType(ident *ast.Ident) types.Object {
 	return nil
 }
 
+// getExprType from any expression
+func (g *GoFile) getExprType(expr ast.Expr) types.Type {
+	for _, pkg := range g.ImportedPackages {
+		if pkg.TypesInfo == nil {
+			continue
+		}
+		if tv, ok := pkg.TypesInfo.Types[expr]; ok {
+			return tv.Type
+		}
+	}
+	return nil
+}
+
 // CheckType for gotext object
 func (g *GoFile) CheckType(rawType types.Type) bool {
+	if rawType == nil {
+		return false
+	}
+
 	switch t := rawType.(type) {
 	case *types.Pointer:
 		return g.CheckType(t.Elem())
@@ -75,6 +92,11 @@ func (g *GoFile) CheckType(rawType types.Type) bool {
 
 	case *types.Alias:
 		return g.CheckType(t.Rhs())
+
+	case *types.Interface:
+		// Check if it's the Translator interface from our package
+		// This is a bit more complex, but usually it's wrapped in a Named type
+		return false
 
 	default:
 		return false
@@ -90,33 +112,19 @@ func (g *GoFile) InspectCallExpr(n *ast.CallExpr) {
 		return
 	}
 
-	switch e := expr.X.(type) {
-	// direct call
-	case *ast.Ident:
-		// object is a package if the Obj is not set
-		if e.Obj == nil {
-			pkg, ok := g.ImportedPackages[e.Name]
+	// Resolve the type of the receiver (expr.X)
+	receiverType := g.getExprType(expr.X)
+	if receiverType == nil {
+		// Fallback for package calls if types didn't resolve it
+		if id, ok := expr.X.(*ast.Ident); ok && id.Obj == nil {
+			pkg, ok := g.ImportedPackages[id.Name]
 			if !ok || pkg.PkgPath != "github.com/leonelquinteros/gotext" {
 				return
 			}
-
 		} else {
-			// validate type of object
-			t := g.GetType(e)
-			if t == nil || !g.CheckType(t.Type()) {
-				return
-			}
-		}
-
-	// call to attribute
-	case *ast.SelectorExpr:
-		// validate type of object
-		t := g.GetType(e.Sel)
-		if t == nil || !g.CheckType(t.Type()) {
 			return
 		}
-
-	default:
+	} else if !g.CheckType(receiverType) {
 		return
 	}
 

--- a/cli/xgotext/parser/pkg-tree/golang_test.go
+++ b/cli/xgotext/parser/pkg-tree/golang_test.go
@@ -33,7 +33,8 @@ string`,
 line
 string
 ending with
-EOL`, "multline\nending with EOL\n", "type alias",
+EOL`, "multline\nending with EOL\n", "type alias", "locale constructor call",
+		"chained locale", "chained po", "chained from func", "from interface",
 	}
 
 	if len(translations) != len(data.Domains[defaultDomain].Translations) {


### PR DESCRIPTION
This PR fixes a bug in  where it failed to extract translatable strings when the translation method (e.g., ) was called on a receiver that resulted from a function call or a chained expression (e.g., ).

Key changes:
- Refactored  in  to use  information for resolving the receiver's type.
- Introduced  helper to handle arbitrary expressions.
- Updated  to be more robust.
- Added several test cases in  and updated  to verify the fix.

Fixes #108