### PR TITLE
Formal Documentation Overhaul

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,20 @@
+name: Publish Documentation
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 
 ---
 
+**📖 [Read the Full Documentation](https://leonelquinteros.github.io/gotext/)**
+
+---
+
 ### Table of Contents
 - [Features](#features)
 - [Installation](#installation)

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -1,0 +1,71 @@
+# Best Practices for gotext
+
+Localized applications can become complex quickly. Following these best practices will help you keep your project maintainable.
+
+## 1. Organise Your Directory Structure
+
+Consistency is key. Use the standard Gettext directory structure:
+
+```
+/locales
+  /en_US
+    /LC_MESSAGES
+      default.po
+      errors.po
+  /es_ES
+    /LC_MESSAGES
+      default.po
+      errors.po
+```
+
+- **LC_MESSAGES**: Always place your `.po` and `.mo` files inside an `LC_MESSAGES` directory or directly under the language code.
+- **Simplified Codes**: provide fallbacks (e.g., provide `es` if `es_AR` and `es_ES` share many strings).
+
+## 2. Use Meaningful Domains
+
+Don't put all your translations in a single "default" domain for large apps. Split them logically:
+- `ui.po`: Interface elements (buttons, labels).
+- `errors.po`: System and error messages.
+- `help.po`: Long-form documentation or help text.
+
+## 3. Leverage Context (`msgctxt`)
+
+Avoid ambiguity by using context for short strings that might have different meanings depending on where they appear.
+
+```go
+// In code:
+gotext.GetC("Open", "File menu")
+gotext.GetC("Open", "Lock status")
+```
+
+```po
+// In PO file:
+msgctxt "File menu"
+msgid "Open"
+msgstr "Abrir"
+
+msgctxt "Lock status"
+msgid "Open"
+msgstr "Abierto"
+```
+
+## 4. Automate String Extraction
+
+Never manually edit `msgid` entries in your `.po` files. Use the `xgotext` CLI tool to scan your code and update your translation files. This ensures your code and translations stay in sync.
+
+```bash
+xgotext -p . -o locales/en_US/default.po
+```
+
+## 5. Thread Safety
+
+`gotext` is thread-safe. You can safely share a `Locale` object across multiple goroutines (e.g., in an HTTP handler). Avoid re-configuring the global package state (`gotext.Configure`) after your application has started.
+
+## 6. Testing
+
+When writing tests for your application, you can use the `Po` object to load small strings directly, which is often faster than setting up a full directory structure.
+
+```go
+po := gotext.NewPo()
+po.Parse([]byte("msgid \"test\"\nmsgstr \"prueba\""))
+```

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at leonel.quinteros@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# CONTRIBUTING
+
+This open source project welcomes everybody that wants to contribute to it by implementing new features, fixing bugs, testing, creating documentation or simply talk about it. 
+
+Most contributions will start by creating a new Issue to discuss what is the contribution about and to agree on the steps to move forward. 
+
+## Issues
+
+All issues reports are welcome. Open a new Issue whenever you want to report a bug, request a change or make a proposal.
+
+This should be your start point of contribution. 
+
+
+## Pull Requests
+
+If you have any changes that can be merged, feel free to send a Pull Request. 
+
+Usually, you'd want to create a new Issue to discuss about the change you want to merge and why it's needed or what it solves. 
+

--- a/docs/ENCODING.md
+++ b/docs/ENCODING.md
@@ -1,0 +1,42 @@
+# Character Encoding with gotext
+
+This guide covers how `gotext` handles character encoding, particularly UTF-8.
+
+## UTF-8 by Default
+
+`gotext` is built to work seamlessly with UTF-8, which is the default encoding for Go source code and strings. We highly recommend using UTF-8 for all your `.po` and `.mo` files.
+
+### Why UTF-8?
+1.  **Consistency**: No need for manual conversion between encodings and Go's internal string representation.
+2.  **Breadth**: Support for almost any character set in a single file.
+3.  **Modern Standard**: UTF-8 is the industry standard for localization.
+
+## Using Other Encodings
+
+While UTF-8 is strongly recommended, the standard GNU Gettext specification allows for other encodings, such as ISO-8859-1.
+
+### Header Configuration
+The encoding of a `.po` file is defined in its header:
+
+```po
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+```
+
+When `gotext` parses these files, it respects the `charset` defined in the `Content-Type` header if possible. However, since Go strings are natively UTF-8, some older encodings may require manual handling or are implicitly converted when read.
+
+## Troubleshooting Encoding Issues
+
+If you see garbled characters or "diamonds" (replacement characters), check the following:
+
+1.  **File Format**: Ensure your `.po` or `.mo` file is actually saved in the encoding specified in its header.
+2.  **Terminal/Display**: Ensure your terminal or UI is configured to display the character set you are using.
+3.  **Go Source**: Ensure your Go source files are saved as UTF-8 (the default for the Go compiler).
+
+## Recommendations
+For the best experience, always:
+- Save `.po` files as **UTF-8 (without BOM)**.
+- Set the `charset` header to `UTF-8`.
+- Use the `xgotext` CLI tool to maintain consistent file formatting.

--- a/docs/LICENSE.md
+++ b/docs/LICENSE.md
@@ -1,0 +1,55 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Leonel Quinteros
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+Package `plurals`
+
+Original:
+    https://github.com/ojii/gettext.go/tree/b6dae1d7af8a8441285e42661565760b530a8a57/pluralforms
+
+License:
+    https://raw.githubusercontent.com/ojii/gettext.go/b6dae1d7af8a8441285e42661565760b530a8a57/LICENSE
+
+    Copyright (c) 2016, Jonas Obrist
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above copyright
+          notice, this list of conditions and the following disclaimer in the
+          documentation and/or other materials provided with the distribution.
+        * Neither the name of Jonas Obrist nor the
+          names of its contributors may be used to endorse or promote products
+          derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL JONAS OBRIST BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,23 @@
+# gotext
+
+GNU gettext utilities for Go.
+
+`gotext` is a native Go implementation of the GNU Gettext utilities. It provides a thread-safe, flexible, and powerful way to handle internationalization (i18n) and localization (l10n) in your Go applications.
+
+## Why use gotext?
+
+- **Native Go**: No external dependencies or CGO required.
+- **Thread-safe**: Designed for concurrent use in web servers and high-performance apps.
+- **Gettext Compatible**: Supports standard `.po` and `.mo` files, including complex plural forms and contexts.
+- **CLI Support**: Includes `xgotext` to automate the extraction of strings from your source code.
+
+## Quick Links
+
+- [Installation](GETTING_STARTED.md#installation)
+- [Basic Usage](GETTING_STARTED.md#2-basic-example-package-level-api)
+- [CLI Tool](xgotext.md)
+- [Plural Forms](PLURALS.md)
+
+## Contributing
+
+We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,39 @@
+site_name: gotext
+site_description: GNU gettext utilities for Go
+site_author: Leonel Quinteros
+repo_url: https://github.com/leonelquinteros/gotext
+edit_uri: edit/master/docs/
+
+theme:
+  name: material
+  palette:
+    primary: indigo
+    accent: indigo
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.suggest
+    - search.highlight
+
+nav:
+  - Home: index.md
+  - Getting Started: GETTING_STARTED.md
+  - User Guides:
+      - Plural Forms: PLURALS.md
+      - xgotext CLI: xgotext.md
+      - Character Encoding: ENCODING.md
+      - Best Practices: BEST_PRACTICES.md
+  - API Reference: https://pkg.go.dev/github.com/leonelquinteros/gotext
+  - Contributing:
+      - Guidelines: CONTRIBUTING.md
+      - Code of Conduct: CODE_OF_CONDUCT.md
+  - License: LICENSE.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences


### PR DESCRIPTION
This PR resolves #26 by providing a formal documentation site built with MkDocs.

Key changes:
- Setup  with the Material theme.
- Added a formal home page ().
- Added a detailed 'Character Encoding' guide.
- Added a 'Best Practices' guide.
- Included legal and community docs in the formal site navigation.
- Added a GitHub Action to automatically deploy the site to GitHub Pages on push to .
- Updated README with a direct link to the formal documentation.

Fixes #26