### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -268,7 +268,7 @@ func (do *Domain) Set(id, str string) {
 }
 
 // Get retrieves the Translation for the given string.
-func (do *Domain) Get(str string, vars ...interface{}) string {
+func (do *Domain) Get(str string, vars ...any) string {
 	// Sync read
 	do.trMutex.RLock()
 	defer do.trMutex.RUnlock()
@@ -284,8 +284,8 @@ func (do *Domain) Get(str string, vars ...interface{}) string {
 }
 
 // Append retrieves the Translation for the given string.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func (do *Domain) Append(b []byte, str string, vars ...interface{}) []byte {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func (do *Domain) Append(b []byte, str string, vars ...any) []byte {
 	// Sync read
 	do.trMutex.RLock()
 	defer do.trMutex.RUnlock()
@@ -322,8 +322,8 @@ func (do *Domain) SetN(id, plural string, n int, str string) {
 }
 
 // GetN retrieves the (N)th plural form of Translation for the given string.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func (do *Domain) GetN(str, plural string, n int, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func (do *Domain) GetN(str, plural string, n int, vars ...any) string {
 	// Sync read
 	do.trMutex.RLock()
 	defer do.trMutex.RUnlock()
@@ -342,8 +342,8 @@ func (do *Domain) GetN(str, plural string, n int, vars ...interface{}) string {
 }
 
 // AppendN adds the (N)th plural form of Translation for the given string.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func (do *Domain) AppendN(b []byte, str, plural string, n int, vars ...interface{}) []byte {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func (do *Domain) AppendN(b []byte, str, plural string, n int, vars ...any) []byte {
 	// Sync read
 	do.trMutex.RLock()
 	defer do.trMutex.RUnlock()
@@ -388,8 +388,8 @@ func (do *Domain) SetC(id, ctx, str string) {
 }
 
 // GetC retrieves the corresponding Translation for a given string in the given context.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func (do *Domain) GetC(str, ctx string, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func (do *Domain) GetC(str, ctx string, vars ...any) string {
 	do.trMutex.RLock()
 	defer do.trMutex.RUnlock()
 
@@ -408,8 +408,8 @@ func (do *Domain) GetC(str, ctx string, vars ...interface{}) string {
 }
 
 // AppendC retrieves the corresponding Translation for a given string in the given context.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func (do *Domain) AppendC(b []byte, str, ctx string, vars ...interface{}) []byte {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func (do *Domain) AppendC(b []byte, str, ctx string, vars ...any) []byte {
 	do.trMutex.RLock()
 	defer do.trMutex.RUnlock()
 
@@ -457,8 +457,8 @@ func (do *Domain) SetNC(id, plural, ctx string, n int, str string) {
 }
 
 // GetNC retrieves the (N)th plural form of Translation for the given string in the given context.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func (do *Domain) GetNC(str, plural string, n int, ctx string, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func (do *Domain) GetNC(str, plural string, n int, ctx string, vars ...any) string {
 	do.trMutex.RLock()
 	defer do.trMutex.RUnlock()
 
@@ -479,8 +479,8 @@ func (do *Domain) GetNC(str, plural string, n int, ctx string, vars ...interface
 }
 
 // AppendNC retrieves the (N)th plural form of Translation for the given string in the given context.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func (do *Domain) AppendNC(b []byte, str, plural string, n int, ctx string, vars ...interface{}) []byte {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func (do *Domain) AppendNC(b []byte, str, plural string, n int, ctx string, vars ...any) []byte {
 	do.trMutex.RLock()
 	defer do.trMutex.RUnlock()
 

--- a/gotext.go
+++ b/gotext.go
@@ -230,20 +230,20 @@ func Configure(lib, lang, dom string) {
 }
 
 // Get uses the default domain globally set to return the corresponding Translation of a given string.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func Get(str string, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func Get(str string, vars ...any) string {
 	return GetD(GetDomain(), str, vars...)
 }
 
 // GetN retrieves the (N)th plural form of Translation for the given string in the default domain.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func GetN(str, plural string, n int, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func GetN(str, plural string, n int, vars ...any) string {
 	return GetND(GetDomain(), str, plural, n, vars...)
 }
 
 // GetD returns the corresponding Translation in the given domain for a given string.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func GetD(dom, str string, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func GetD(dom, str string, vars ...any) string {
 	// Try to load default package Locales
 	loadLocales(false)
 
@@ -265,8 +265,8 @@ func GetD(dom, str string, vars ...interface{}) string {
 }
 
 // GetND retrieves the (N)th plural form of Translation in the given domain for a given string.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func GetND(dom, str, plural string, n int, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func GetND(dom, str, plural string, n int, vars ...any) string {
 	// Try to load default package Locales
 	loadLocales(false)
 
@@ -288,20 +288,20 @@ func GetND(dom, str, plural string, n int, vars ...interface{}) string {
 }
 
 // GetC uses the default domain globally set to return the corresponding Translation of the given string in the given context.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func GetC(str, ctx string, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func GetC(str, ctx string, vars ...any) string {
 	return GetDC(GetDomain(), str, ctx, vars...)
 }
 
 // GetNC retrieves the (N)th plural form of Translation for the given string in the given context in the default domain.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func GetNC(str, plural string, n int, ctx string, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func GetNC(str, plural string, n int, ctx string, vars ...any) string {
 	return GetNDC(GetDomain(), str, plural, n, ctx, vars...)
 }
 
 // GetDC returns the corresponding Translation in the given domain for the given string in the given context.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func GetDC(dom, str, ctx string, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func GetDC(dom, str, ctx string, vars ...any) string {
 	// Try to load default package Locales
 	loadLocales(false)
 
@@ -320,8 +320,8 @@ func GetDC(dom, str, ctx string, vars ...interface{}) string {
 }
 
 // GetNDC retrieves the (N)th plural form of Translation in the given domain for a given string.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func GetNDC(dom, str, plural string, n int, ctx string, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func GetNDC(dom, str, plural string, n int, ctx string, vars ...any) string {
 	// Try to load default package Locales
 	loadLocales(false)
 

--- a/helper.go
+++ b/helper.go
@@ -29,7 +29,7 @@ func SimplifiedLocale(lang string) string {
 }
 
 // FormatString applies text formatting only when needed to parse variables.
-func FormatString(str string, vars ...interface{}) string {
+func FormatString(str string, vars ...any) string {
 	if len(vars) > 0 {
 		return FormatStringWithArgs(str, vars)
 	}
@@ -38,12 +38,12 @@ func FormatString(str string, vars ...interface{}) string {
 }
 
 // FormatStringWithArgs applies text formatting as a proxy for fmt.Sprintf.
-func FormatStringWithArgs(str string, vars []interface{}) string {
+func FormatStringWithArgs(str string, vars []any) string {
 	return fmt.Sprintf(str, vars...)
 }
 
 // Appendf applies text formatting only when needed to parse variables.
-func Appendf(b []byte, str string, vars ...interface{}) []byte {
+func Appendf(b []byte, str string, vars ...any) []byte {
 	if len(vars) > 0 {
 		return fmt.Appendf(b, str, vars...)
 	}
@@ -52,23 +52,23 @@ func Appendf(b []byte, str string, vars ...interface{}) []byte {
 }
 
 // NPrintf support named format
-// NPrintf("%(name)s is Type %(type)s", map[string]interface{}{"name": "Gotext", "type": "struct"})
-func NPrintf(format string, params map[string]interface{}) {
+// NPrintf("%(name)s is Type %(type)s", map[string]any{"name": "Gotext", "type": "struct"})
+func NPrintf(format string, params map[string]any) {
 	f, p := parseSprintf(format, params)
 	fmt.Printf(f, p...)
 }
 
 // Sprintf support named format
 //
-//	Sprintf("%(name)s is Type %(type)s", map[string]interface{}{"name": "Gotext", "type": "struct"})
-func Sprintf(format string, params map[string]interface{}) string {
+//	Sprintf("%(name)s is Type %(type)s", map[string]any{"name": "Gotext", "type": "struct"})
+func Sprintf(format string, params map[string]any) string {
 	f, p := parseSprintf(format, params)
 	return fmt.Sprintf(f, p...)
 }
 
-func parseSprintf(format string, params map[string]interface{}) (string, []interface{}) {
+func parseSprintf(format string, params map[string]any) (string, []any) {
 	f, n := reformatSprintf(format)
-	var p []interface{}
+	var p []any
 	for _, v := range n {
 		p = append(p, params[v])
 	}

--- a/helper_test.go
+++ b/helper_test.go
@@ -71,7 +71,7 @@ func TestReformattingRepeatedNamedPattern(t *testing.T) {
 
 func TestSprintf(t *testing.T) {
 	pat := "%(brother)s loves %(sister)s. %(sister)s also loves %(brother)s."
-	params := map[string]interface{}{
+	params := map[string]any{
 		"sister":  "Susan",
 		"brother": "Louis",
 	}
@@ -85,7 +85,7 @@ func TestSprintf(t *testing.T) {
 
 func TestNPrintf(t *testing.T) {
 	pat := "%(brother)s loves %(sister)s. %(sister)s also loves %(brother)s.\n"
-	params := map[string]interface{}{
+	params := map[string]any{
 		"sister":  "Susan",
 		"brother": "Louis",
 	}
@@ -96,7 +96,7 @@ func TestNPrintf(t *testing.T) {
 
 func TestSprintfFloatsWithPrecision(t *testing.T) {
 	pat := "%(float)f / %(floatprecision).1f / %(long)g / %(longprecision).3g"
-	params := map[string]interface{}{
+	params := map[string]any{
 		"float":          5.034560,
 		"floatprecision": 5.03456,
 		"long":           5.03456,

--- a/locale.go
+++ b/locale.go
@@ -237,20 +237,20 @@ func (l *Locale) GetLanguage() string {
 }
 
 // Get uses a domain "default" to return the corresponding Translation of a given string.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func (l *Locale) Get(str string, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) Get(str string, vars ...any) string {
 	return l.GetD(l.GetDomain(), str, vars...)
 }
 
 // GetN retrieves the (N)th plural form of Translation for the given string in the "default" domain.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func (l *Locale) GetN(str, plural string, n int, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) GetN(str, plural string, n int, vars ...any) string {
 	return l.GetND(l.GetDomain(), str, plural, n, vars...)
 }
 
 // GetD returns the corresponding Translation in the given domain for the given string.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func (l *Locale) GetD(dom, str string, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) GetD(dom, str string, vars ...any) string {
 	// Sync read
 	l.RLock()
 	defer l.RUnlock()
@@ -267,8 +267,8 @@ func (l *Locale) GetD(dom, str string, vars ...interface{}) string {
 }
 
 // GetND retrieves the (N)th plural form of Translation in the given domain for the given string.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func (l *Locale) GetND(dom, str, plural string, n int, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) GetND(dom, str, plural string, n int, vars ...any) string {
 	// Sync read
 	l.RLock()
 	defer l.RUnlock()
@@ -289,20 +289,20 @@ func (l *Locale) GetND(dom, str, plural string, n int, vars ...interface{}) stri
 }
 
 // GetC uses a domain "default" to return the corresponding Translation of the given string in the given context.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func (l *Locale) GetC(str, ctx string, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) GetC(str, ctx string, vars ...any) string {
 	return l.GetDC(l.GetDomain(), str, ctx, vars...)
 }
 
 // GetNC retrieves the (N)th plural form of Translation for the given string in the given context in the "default" domain.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func (l *Locale) GetNC(str, plural string, n int, ctx string, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) GetNC(str, plural string, n int, ctx string, vars ...any) string {
 	return l.GetNDC(l.GetDomain(), str, plural, n, ctx, vars...)
 }
 
 // GetDC returns the corresponding Translation in the given domain for the given string in the given context.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func (l *Locale) GetDC(dom, str, ctx string, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) GetDC(dom, str, ctx string, vars ...any) string {
 	// Sync read
 	l.RLock()
 	defer l.RUnlock()
@@ -319,8 +319,8 @@ func (l *Locale) GetDC(dom, str, ctx string, vars ...interface{}) string {
 }
 
 // GetNDC retrieves the (N)th plural form of Translation in the given domain for the given string in the given context.
-// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
-func (l *Locale) GetNDC(dom, str, plural string, n int, ctx string, vars ...interface{}) string {
+// Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) GetNDC(dom, str, plural string, n int, ctx string, vars ...any) string {
 	// Sync read
 	l.RLock()
 	defer l.RUnlock()

--- a/mo.go
+++ b/mo.go
@@ -76,42 +76,42 @@ func (mo *Mo) GetDomain() *Domain {
 }
 
 // Get returns the translation for the given string
-func (mo *Mo) Get(str string, vars ...interface{}) string {
+func (mo *Mo) Get(str string, vars ...any) string {
 	return mo.domain.Get(str, vars...)
 }
 
 // Append a translation string into the domain
-func (mo *Mo) Append(b []byte, str string, vars ...interface{}) []byte {
+func (mo *Mo) Append(b []byte, str string, vars ...any) []byte {
 	return mo.domain.Append(b, str, vars...)
 }
 
 // GetN returns the translation for the given string and plural form
-func (mo *Mo) GetN(str, plural string, n int, vars ...interface{}) string {
+func (mo *Mo) GetN(str, plural string, n int, vars ...any) string {
 	return mo.domain.GetN(str, plural, n, vars...)
 }
 
 // AppendN appends a translation string for the given plural form into the domain
-func (mo *Mo) AppendN(b []byte, str, plural string, n int, vars ...interface{}) []byte {
+func (mo *Mo) AppendN(b []byte, str, plural string, n int, vars ...any) []byte {
 	return mo.domain.AppendN(b, str, plural, n, vars...)
 }
 
 // GetC returns the translation for the given string and context
-func (mo *Mo) GetC(str, ctx string, vars ...interface{}) string {
+func (mo *Mo) GetC(str, ctx string, vars ...any) string {
 	return mo.domain.GetC(str, ctx, vars...)
 }
 
 // AppendC appends a translation string for the given context into the domain
-func (mo *Mo) AppendC(b []byte, str, ctx string, vars ...interface{}) []byte {
+func (mo *Mo) AppendC(b []byte, str, ctx string, vars ...any) []byte {
 	return mo.domain.AppendC(b, str, ctx, vars...)
 }
 
 // GetNC returns the translation for the given string, plural form and context
-func (mo *Mo) GetNC(str, plural string, n int, ctx string, vars ...interface{}) string {
+func (mo *Mo) GetNC(str, plural string, n int, ctx string, vars ...any) string {
 	return mo.domain.GetNC(str, plural, n, ctx, vars...)
 }
 
 // AppendNC appends a translation string for the given plural form and context into the domain
-func (mo *Mo) AppendNC(b []byte, str, plural string, n int, ctx string, vars ...interface{}) []byte {
+func (mo *Mo) AppendNC(b []byte, str, plural string, n int, ctx string, vars ...any) []byte {
 	return mo.domain.AppendNC(b, str, plural, n, ctx, vars...)
 }
 

--- a/po.go
+++ b/po.go
@@ -103,12 +103,12 @@ func (po *Po) Set(id, str string) {
 }
 
 // Get translation
-func (po *Po) Get(str string, vars ...interface{}) string {
+func (po *Po) Get(str string, vars ...any) string {
 	return po.domain.Get(str, vars...)
 }
 
 // Append translation
-func (po *Po) Append(b []byte, str string, vars ...interface{}) []byte {
+func (po *Po) Append(b []byte, str string, vars ...any) []byte {
 	return po.domain.Append(b, str, vars...)
 }
 
@@ -118,12 +118,12 @@ func (po *Po) SetN(id, plural string, n int, str string) {
 }
 
 // GetN gets the plural translation
-func (po *Po) GetN(str, plural string, n int, vars ...interface{}) string {
+func (po *Po) GetN(str, plural string, n int, vars ...any) string {
 	return po.domain.GetN(str, plural, n, vars...)
 }
 
 // AppendN appends the plural translation
-func (po *Po) AppendN(b []byte, str, plural string, n int, vars ...interface{}) []byte {
+func (po *Po) AppendN(b []byte, str, plural string, n int, vars ...any) []byte {
 	return po.domain.AppendN(b, str, plural, n, vars...)
 }
 
@@ -133,12 +133,12 @@ func (po *Po) SetC(id, ctx, str string) {
 }
 
 // GetC gets the translation for a given context
-func (po *Po) GetC(str, ctx string, vars ...interface{}) string {
+func (po *Po) GetC(str, ctx string, vars ...any) string {
 	return po.domain.GetC(str, ctx, vars...)
 }
 
 // AppendC appends the translation for a given context
-func (po *Po) AppendC(b []byte, str, ctx string, vars ...interface{}) []byte {
+func (po *Po) AppendC(b []byte, str, ctx string, vars ...any) []byte {
 	return po.domain.AppendC(b, str, ctx, vars...)
 }
 
@@ -148,12 +148,12 @@ func (po *Po) SetNC(id, plural, ctx string, n int, str string) {
 }
 
 // GetNC gets the plural translation for a given context
-func (po *Po) GetNC(str, plural string, n int, ctx string, vars ...interface{}) string {
+func (po *Po) GetNC(str, plural string, n int, ctx string, vars ...any) string {
 	return po.domain.GetNC(str, plural, n, ctx, vars...)
 }
 
 // AppendNC appends the plural translation for a given context
-func (po *Po) AppendNC(b []byte, str, plural string, n int, ctx string, vars ...interface{}) []byte {
+func (po *Po) AppendNC(b []byte, str, plural string, n int, ctx string, vars ...any) []byte {
 	return po.domain.AppendNC(b, str, plural, n, ctx, vars...)
 }
 

--- a/translator.go
+++ b/translator.go
@@ -17,10 +17,10 @@ import (
 type Translator interface {
 	ParseFile(f string)
 	Parse(buf []byte)
-	Get(str string, vars ...interface{}) string
-	GetN(str, plural string, n int, vars ...interface{}) string
-	GetC(str, ctx string, vars ...interface{}) string
-	GetNC(str, plural string, n int, ctx string, vars ...interface{}) string
+	Get(str string, vars ...any) string
+	GetN(str, plural string, n int, vars ...any) string
+	GetC(str, ctx string, vars ...any) string
+	GetNC(str, plural string, n int, ctx string, vars ...any) string
 
 	MarshalBinary() ([]byte, error)
 	UnmarshalBinary([]byte) error
@@ -31,10 +31,10 @@ type Translator interface {
 // It contains all methods needed to parse translation sources and to append entries to the object.
 type AppendTranslator interface {
 	Translator
-	Append(b []byte, str string, vars ...interface{}) []byte
-	AppendN(b []byte, str, plural string, n int, vars ...interface{}) []byte
-	AppendC(b []byte, str, ctx string, vars ...interface{}) []byte
-	AppendNC(b []byte, str, plural string, n int, ctx string, vars ...interface{}) []byte
+	Append(b []byte, str string, vars ...any) []byte
+	AppendN(b []byte, str, plural string, n int, vars ...any) []byte
+	AppendC(b []byte, str, ctx string, vars ...any) []byte
+	AppendNC(b []byte, str, plural string, n int, ctx string, vars ...any) []byte
 }
 
 // TranslatorEncoding is used as intermediary storage to encode Translator objects to Gob.


### PR DESCRIPTION
Go 1.18 introduced `any` as an alias for `interface{}`. Since the module requires Go 1.25, this change replaces all `interface{}` type literals with `any`.

This is a pure refactor with no functional changes.