### PR TITLE
fix(xgotext): extract static string identifiers safely

### DIFF
--- a/cli/xgotext/fixtures/main.go
+++ b/cli/xgotext/fixtures/main.go
@@ -13,6 +13,14 @@ import (
 type Fake struct {
 }
 
+const (
+	ConstantTesting = "this is constant testing"
+)
+
+var (
+	variableTesting = "this is variable testing"
+)
+
 // Get by id
 func (f Fake) Get(id int) int {
 	return 42
@@ -38,6 +46,12 @@ var NL = func() *gotext.Locale {
 func main() {
 	// Configure package
 	gotext.Configure("/path/to/locales/root/dir", "en_UK", "domain-name")
+
+	// constant testing
+	fmt.Println(gotext.Get(ConstantTesting))
+
+	// variable testing
+	fmt.Println(gotext.Get(variableTesting))
 
 	// Translate text from default domain
 	fmt.Println(gotext.Get("My text on 'domain-name' domain"))

--- a/cli/xgotext/fixtures/main.go
+++ b/cli/xgotext/fixtures/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/leonelquinteros/gotext"       //nolint:staticcheck
 	alias "github.com/leonelquinteros/gotext" //nolint:staticcheck
@@ -15,6 +16,16 @@ type Fake struct {
 
 const (
 	ConstantTesting = "this is constant testing"
+	MultiConst1     = "this is multi const 1"
+	MultiConst2     = "this is multi const 2"
+	DomainConst     = "constants"
+	MessageConst    = "message from a constant"
+	PluralSingular  = "singular from a constant"
+	Plural          = "plural from a constant"
+	ContextMessage  = "message with a constant context"
+	Context         = "constant context"
+	AliasMessage    = MessageConst
+	ConcatMessage   = "concatenated" + " constant"
 )
 
 var (
@@ -49,9 +60,24 @@ func main() {
 
 	// constant testing
 	fmt.Println(gotext.Get(ConstantTesting))
+	fmt.Println(gotext.Get(MultiConst1))
+	fmt.Println(gotext.Get(MultiConst2))
+	fmt.Println(gotext.Get(AliasMessage))
+	fmt.Println(gotext.Get(ConcatMessage))
+	fmt.Println(gotext.GetD(DomainConst, MessageConst))
+	fmt.Println(gotext.GetN(PluralSingular, Plural, 2))
+	fmt.Println(gotext.GetC(ContextMessage, Context))
 
 	// variable testing
 	fmt.Println(gotext.Get(variableTesting))
+	multiVar1, multiVar2 := "this is multi var 1", "this is multi var 2"
+	fmt.Println(gotext.Get(multiVar1))
+	fmt.Println(gotext.Get(multiVar2))
+	mutatedMessage := "message before mutation"
+	mutatedMessage = "message after mutation"
+	fmt.Println(gotext.Get(mutatedMessage))
+	dynamicDomain := os.Getenv("GOTEXT_DOMAIN")
+	fmt.Println(gotext.GetD(dynamicDomain, "message with a dynamic domain"))
 
 	// Translate text from default domain
 	fmt.Println(gotext.Get("My text on 'domain-name' domain"))

--- a/cli/xgotext/fixtures/main.go
+++ b/cli/xgotext/fixtures/main.go
@@ -74,6 +74,7 @@ func main() {
 	fmt.Println(gotext.Get(multiVar1))
 	fmt.Println(gotext.Get(multiVar2))
 	mutatedMessage := "message before mutation"
+	fmt.Println(mutatedMessage)
 	mutatedMessage = "message after mutation"
 	fmt.Println(gotext.Get(mutatedMessage))
 	dynamicDomain := os.Getenv("GOTEXT_DOMAIN")

--- a/cli/xgotext/parser/dir/golang_test.go
+++ b/cli/xgotext/parser/dir/golang_test.go
@@ -1,0 +1,36 @@
+package dir
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/leonelquinteros/gotext/cli/xgotext/parser"
+)
+
+func TestGoParserExtractsStaticStrings(t *testing.T) {
+	data := &parser.DomainMap{Default: "default"}
+	fixtures := filepath.Join("..", "..", "fixtures")
+
+	if err := goParser(fixtures, fixtures, data); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := data.Domains["constants"].Translations["message from a constant"]; !ok {
+		t.Error("constant domain and message were not extracted")
+	}
+	if plural := data.Domains["default"].Translations["singular from a constant"]; plural == nil || plural.MsgIDPlural != "plural from a constant" {
+		t.Error("constant plural strings were not extracted")
+	}
+	if _, ok := data.Domains["default"].ContextTranslations[`"constant context"`]["message with a constant context"]; !ok {
+		t.Error("constant context and message were not extracted")
+	}
+	if _, ok := data.Domains["default"].Translations["message before mutation"]; ok {
+		t.Error("mutated variable should not be extracted")
+	}
+	if _, ok := data.Domains["default"].Translations["message after mutation"]; ok {
+		t.Error("mutated variable should not be extracted")
+	}
+	if _, ok := data.Domains["default"].Translations["message with a dynamic domain"]; ok {
+		t.Error("dynamic domain should not be extracted")
+	}
+}

--- a/cli/xgotext/parser/gofile.go
+++ b/cli/xgotext/parser/gofile.go
@@ -131,37 +131,32 @@ func (g *GoFile) InspectCallExpr(n *ast.CallExpr) {
 	// convert args
 	args := make([]*ast.BasicLit, len(n.Args))
 	for idx, arg := range n.Args {
-		var (
-			basicLitOk, identOk bool
-			ident               *ast.Ident
-			exprList            []ast.Expr
-		)
-
-		basicLit, basicLitOk := arg.(*ast.BasicLit)
-		if !basicLitOk {
-			ident, identOk = arg.(*ast.Ident)
+		args[idx] = nil // create default value
+		basicLit, ok := arg.(*ast.BasicLit)
+		if ok {
+			args[idx] = basicLit
+			continue
 		}
 
-		if identOk && ident.Obj != nil {
-			switch decl := ident.Obj.Decl.(type) {
-			case *ast.AssignStmt:
-				exprList = decl.Rhs
-			case *ast.ValueSpec:
-				exprList = decl.Values
+		ident, ok := arg.(*ast.Ident)
+		if !ok || ident.Obj == nil {
+			continue
+		}
+
+		var exprList []ast.Expr
+		switch decl := ident.Obj.Decl.(type) {
+		case *ast.AssignStmt:
+			exprList = decl.Rhs
+		case *ast.ValueSpec:
+			exprList = decl.Values
+		}
+
+		for _, e := range exprList {
+			if bl, ok := e.(*ast.BasicLit); ok && bl.Kind == token.STRING {
+				args[idx] = bl
+				break
 			}
 		}
-
-		if basicLit == nil {
-			for _, e := range exprList {
-				bl2, bl2Ok := e.(*ast.BasicLit)
-				if bl2Ok && bl2.Kind == token.STRING {
-					basicLit = bl2
-					break
-				}
-			}
-		}
-
-		args[idx] = basicLit
 	}
 
 	// get position

--- a/cli/xgotext/parser/gofile.go
+++ b/cli/xgotext/parser/gofile.go
@@ -131,7 +131,32 @@ func (g *GoFile) InspectCallExpr(n *ast.CallExpr) {
 	// convert args
 	args := make([]*ast.BasicLit, len(n.Args))
 	for idx, arg := range n.Args {
-		args[idx], _ = arg.(*ast.BasicLit)
+		var (
+			basicLitOk, identOk, assignStmtOk bool
+			ident                             *ast.Ident
+			assignStmt                        *ast.AssignStmt
+		)
+
+		basicLit, basicLitOk := arg.(*ast.BasicLit)
+		if !basicLitOk {
+			ident, identOk = arg.(*ast.Ident)
+		}
+
+		if identOk && ident.Obj != nil {
+			assignStmt, assignStmtOk = ident.Obj.Decl.(*ast.AssignStmt)
+		}
+
+		if assignStmtOk {
+			for _, rh := range assignStmt.Rhs {
+				bl2, bl2Ok := rh.(*ast.BasicLit)
+				if bl2Ok && bl2.Kind == token.STRING {
+					basicLit = bl2
+					break
+				}
+			}
+		}
+
+		args[idx] = basicLit
 	}
 
 	// get position

--- a/cli/xgotext/parser/gofile.go
+++ b/cli/xgotext/parser/gofile.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 	"go/ast"
+	"go/constant"
 	"go/token"
 	"go/types"
 	"log"
@@ -131,32 +132,7 @@ func (g *GoFile) InspectCallExpr(n *ast.CallExpr) {
 	// convert args
 	args := make([]*ast.BasicLit, len(n.Args))
 	for idx, arg := range n.Args {
-		args[idx] = nil // create default value
-		basicLit, ok := arg.(*ast.BasicLit)
-		if ok {
-			args[idx] = basicLit
-			continue
-		}
-
-		ident, ok := arg.(*ast.Ident)
-		if !ok || ident.Obj == nil {
-			continue
-		}
-
-		var exprList []ast.Expr
-		switch decl := ident.Obj.Decl.(type) {
-		case *ast.AssignStmt:
-			exprList = decl.Rhs
-		case *ast.ValueSpec:
-			exprList = decl.Values
-		}
-
-		for _, e := range exprList {
-			if bl, ok := e.(*ast.BasicLit); ok && bl.Kind == token.STRING {
-				args[idx] = bl
-				break
-			}
-		}
+		args[idx] = g.resolveStringLiteral(arg, n.Pos(), make(map[types.Object]bool))
 	}
 
 	// get position
@@ -180,37 +156,162 @@ func (g *GoFile) ParseGetter(def GetterDef, args []*ast.BasicLit, pos string) {
 	// get domain
 	var domain string
 	if def.Domain != -1 {
-		domain, _ = strconv.Unquote(args[def.Domain].Value)
+		var ok bool
+		domain, ok = getStringArgument(args, def.Domain, "domain", pos)
+		if !ok {
+			return
+		}
 	}
 
 	// only handle function calls with strings as ID
-	if args[def.ID] == nil || args[def.ID].Kind != token.STRING {
-		log.Printf("ERR: Unsupported call at %s (ID not a string)", pos)
+	msgID, ok := getStringArgument(args, def.ID, "ID", pos)
+	if !ok {
 		return
 	}
 
-	msgID, _ := strconv.Unquote(args[def.ID].Value)
 	trans := Translation{
 		MsgID:           msgID,
 		SourceLocations: []string{pos},
 	}
 	if def.Plural > 0 {
 		// plural ID must be a string
-		if args[def.Plural] == nil || args[def.Plural].Kind != token.STRING {
-			log.Printf("ERR: Unsupported call at %s (Plural not a string)", pos)
+		msgIDPlural, ok := getStringArgument(args, def.Plural, "plural", pos)
+		if !ok {
 			return
 		}
-		msgIDPlural, _ := strconv.Unquote(args[def.Plural].Value)
 		trans.MsgIDPlural = msgIDPlural
 	}
 	if def.Context > 0 {
 		// Context must be a string
-		if args[def.Context] == nil || args[def.Context].Kind != token.STRING {
-			log.Printf("ERR: Unsupported call at %s (Context not a string)", pos)
+		if !isStringArgument(args, def.Context, "context", pos) {
 			return
 		}
 		trans.Context = args[def.Context].Value
 	}
 
 	g.Data.AddTranslation(domain, &trans)
+}
+
+func getStringArgument(args []*ast.BasicLit, index int, name, pos string) (string, bool) {
+	if !isStringArgument(args, index, name, pos) {
+		return "", false
+	}
+
+	value, err := strconv.Unquote(args[index].Value)
+	if err != nil {
+		log.Printf("ERR: Unsupported call at %s (%s is not a valid string)", pos, name)
+		return "", false
+	}
+	return value, true
+}
+
+func isStringArgument(args []*ast.BasicLit, index int, name, pos string) bool {
+	if index < 0 || index >= len(args) || args[index] == nil || args[index].Kind != token.STRING {
+		log.Printf("ERR: Unsupported call at %s (%s is not a string)", pos, name)
+		return false
+	}
+	return true
+}
+
+func (g *GoFile) resolveStringLiteral(expr ast.Expr, before token.Pos, resolving map[types.Object]bool) *ast.BasicLit {
+	if literal, ok := expr.(*ast.BasicLit); ok && literal.Kind == token.STRING {
+		return literal
+	}
+
+	if literal := g.constantStringLiteral(expr); literal != nil {
+		return literal
+	}
+
+	ident, ok := expr.(*ast.Ident)
+	if !ok || ident.Obj == nil {
+		return nil
+	}
+	object := g.getObject(ident)
+	if object != nil {
+		if resolving[object] || g.isMutatedBefore(object, before) {
+			return nil
+		}
+		resolving[object] = true
+		defer delete(resolving, object)
+	}
+
+	switch decl := ident.Obj.Decl.(type) {
+	case *ast.ValueSpec:
+		for i, name := range decl.Names {
+			if name.Name == ident.Name && i < len(decl.Values) {
+				return g.resolveStringLiteral(decl.Values[i], decl.Pos(), resolving)
+			}
+		}
+	case *ast.AssignStmt:
+		for i, lhs := range decl.Lhs {
+			if id, ok := lhs.(*ast.Ident); ok && id.Name == ident.Name && i < len(decl.Rhs) {
+				return g.resolveStringLiteral(decl.Rhs[i], decl.Pos(), resolving)
+			}
+		}
+	}
+	return nil
+}
+
+// getLiteralFromIdent resolves a declaration without package type information.
+// It is retained for focused AST tests; production extraction uses resolveStringLiteral.
+func getLiteralFromIdent(ident *ast.Ident) *ast.BasicLit {
+	return (&GoFile{}).resolveStringLiteral(ident, token.NoPos, make(map[types.Object]bool))
+}
+
+func (g *GoFile) constantStringLiteral(expr ast.Expr) *ast.BasicLit {
+	for _, pkg := range g.ImportedPackages {
+		if pkg.TypesInfo == nil {
+			continue
+		}
+		if value, ok := pkg.TypesInfo.Types[expr]; ok && value.Value != nil && value.Value.Kind() == constant.String {
+			return &ast.BasicLit{Kind: token.STRING, Value: strconv.Quote(constant.StringVal(value.Value))}
+		}
+	}
+	return nil
+}
+
+func (g *GoFile) getObject(ident *ast.Ident) types.Object {
+	for _, pkg := range g.ImportedPackages {
+		if pkg.TypesInfo == nil {
+			continue
+		}
+		if object := pkg.TypesInfo.Uses[ident]; object != nil {
+			return object
+		}
+	}
+	return nil
+}
+
+// isMutatedBefore reports whether a variable has been assigned a new value before its use.
+func (g *GoFile) isMutatedBefore(object types.Object, before token.Pos) bool {
+	if _, ok := object.(*types.Var); !ok {
+		return false
+	}
+
+	for _, pkg := range g.ImportedPackages {
+		if pkg.TypesInfo == nil {
+			continue
+		}
+		for _, file := range pkg.Syntax {
+			mutated := false
+			ast.Inspect(file, func(node ast.Node) bool {
+				assign, ok := node.(*ast.AssignStmt)
+				if !ok || assign.Pos() >= before {
+					return true
+				}
+				for _, lhs := range assign.Lhs {
+					ident, ok := lhs.(*ast.Ident)
+					if ok && pkg.TypesInfo.Uses[ident] == object {
+						mutated = true
+						return false
+					}
+				}
+				return true
+			})
+			if mutated {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/cli/xgotext/parser/gofile.go
+++ b/cli/xgotext/parser/gofile.go
@@ -132,9 +132,9 @@ func (g *GoFile) InspectCallExpr(n *ast.CallExpr) {
 	args := make([]*ast.BasicLit, len(n.Args))
 	for idx, arg := range n.Args {
 		var (
-			basicLitOk, identOk, assignStmtOk bool
-			ident                             *ast.Ident
-			assignStmt                        *ast.AssignStmt
+			basicLitOk, identOk bool
+			ident               *ast.Ident
+			exprList            []ast.Expr
 		)
 
 		basicLit, basicLitOk := arg.(*ast.BasicLit)
@@ -143,12 +143,17 @@ func (g *GoFile) InspectCallExpr(n *ast.CallExpr) {
 		}
 
 		if identOk && ident.Obj != nil {
-			assignStmt, assignStmtOk = ident.Obj.Decl.(*ast.AssignStmt)
+			switch decl := ident.Obj.Decl.(type) {
+			case *ast.AssignStmt:
+				exprList = decl.Rhs
+			case *ast.ValueSpec:
+				exprList = decl.Values
+			}
 		}
 
-		if assignStmtOk {
-			for _, rh := range assignStmt.Rhs {
-				bl2, bl2Ok := rh.(*ast.BasicLit)
+		if basicLit == nil {
+			for _, e := range exprList {
+				bl2, bl2Ok := e.(*ast.BasicLit)
 				if bl2Ok && bl2.Kind == token.STRING {
 					basicLit = bl2
 					break

--- a/cli/xgotext/parser/gofile_test.go
+++ b/cli/xgotext/parser/gofile_test.go
@@ -94,6 +94,10 @@ func TestGoFile_ParseGetter_Errors(t *testing.T) {
 		{Kind: token.INT, Value: "123"},
 	}
 	g.ParseGetter(defGet, args2, "file.go:20")
+
+	// Missing or unsupported arguments must not cause an index-out-of-range panic.
+	g.ParseGetter(defGet, nil, "file.go:30")
+	g.ParseGetter(gotextGetter["GetD"], []*ast.BasicLit{nil}, "file.go:40")
 }
 
 func TestGetLiteralFromIdent(t *testing.T) {

--- a/cli/xgotext/parser/gofile_test.go
+++ b/cli/xgotext/parser/gofile_test.go
@@ -96,3 +96,48 @@ func TestGoFile_ParseGetter_Errors(t *testing.T) {
 	g.ParseGetter(defGet, args2, "file.go:20")
 }
 
+func TestGetLiteralFromIdent(t *testing.T) {
+	// ValueSpec multi-var: const (A = "valA"; B = "valB")
+	valA := &ast.BasicLit{Kind: token.STRING, Value: `"valA"`}
+	valB := &ast.BasicLit{Kind: token.STRING, Value: `"valB"`}
+	identA := &ast.Ident{Name: "A"}
+	identB := &ast.Ident{Name: "B"}
+	spec := &ast.ValueSpec{
+		Names:  []*ast.Ident{identA, identB},
+		Values: []ast.Expr{valA, valB},
+	}
+	identA.Obj = &ast.Object{Decl: spec} //nolint:staticcheck
+	identB.Obj = &ast.Object{Decl: spec} //nolint:staticcheck
+
+	litA := getLiteralFromIdent(identA)
+	if litA == nil || litA.Value != `"valA"` {
+		t.Errorf("expected valA, got %v", litA)
+	}
+
+	litB := getLiteralFromIdent(identB)
+	if litB == nil || litB.Value != `"valB"` {
+		t.Errorf("expected valB, got %v", litB)
+	}
+
+	// AssignStmt multi-var: x, y := "valX", "valY"
+	valX := &ast.BasicLit{Kind: token.STRING, Value: `"valX"`}
+	valY := &ast.BasicLit{Kind: token.STRING, Value: `"valY"`}
+	identX := &ast.Ident{Name: "x"}
+	identY := &ast.Ident{Name: "y"}
+	assign := &ast.AssignStmt{
+		Lhs: []ast.Expr{identX, identY},
+		Rhs: []ast.Expr{valX, valY},
+	}
+	identX.Obj = &ast.Object{Decl: assign} //nolint:staticcheck
+	identY.Obj = &ast.Object{Decl: assign} //nolint:staticcheck
+
+	litX := getLiteralFromIdent(identX)
+	if litX == nil || litX.Value != `"valX"` {
+		t.Errorf("expected valX, got %v", litX)
+	}
+
+	litY := getLiteralFromIdent(identY)
+	if litY == nil || litY.Value != `"valY"` {
+		t.Errorf("expected valY, got %v", litY)
+	}
+}

--- a/cli/xgotext/parser/pkg-tree/golang_test.go
+++ b/cli/xgotext/parser/pkg-tree/golang_test.go
@@ -36,8 +36,15 @@ ending with
 EOL`, "multline\nending with EOL\n", "type alias", "locale constructor call",
 		"chained locale", "chained po", "chained from func", "from interface",
 		"this is constant testing",
+		"this is multi const 1",
+		"this is multi const 2",
 		"this is variable testing",
+		"this is multi var 1",
+		"this is multi var 2",
 		"some string to translate",
+		"message from a constant",
+		"concatenated constant",
+		"singular from a constant",
 	}
 
 	if len(translations) != len(data.Domains[defaultDomain].Translations) {
@@ -47,5 +54,23 @@ EOL`, "multline\nending with EOL\n", "type alias", "locale constructor call",
 		if _, ok := data.Domains[defaultDomain].Translations[tr]; !ok {
 			t.Errorf("translation '%v' not in result", tr)
 		}
+	}
+	if _, ok := data.Domains["constants"].Translations["message from a constant"]; !ok {
+		t.Error("constant domain and message were not extracted")
+	}
+	if plural := data.Domains[defaultDomain].Translations["singular from a constant"]; plural == nil || plural.MsgIDPlural != "plural from a constant" {
+		t.Error("constant plural strings were not extracted")
+	}
+	if _, ok := data.Domains[defaultDomain].ContextTranslations[`"constant context"`]["message with a constant context"]; !ok {
+		t.Error("constant context and message were not extracted")
+	}
+	if _, ok := data.Domains[defaultDomain].Translations["message before mutation"]; ok {
+		t.Error("mutated variable should not be extracted")
+	}
+	if _, ok := data.Domains[defaultDomain].Translations["message after mutation"]; ok {
+		t.Error("mutated variable should not be extracted")
+	}
+	if _, ok := data.Domains[defaultDomain].Translations["message with a dynamic domain"]; ok {
+		t.Error("dynamic domain should not be extracted")
 	}
 }

--- a/cli/xgotext/parser/pkg-tree/golang_test.go
+++ b/cli/xgotext/parser/pkg-tree/golang_test.go
@@ -35,6 +35,9 @@ string
 ending with
 EOL`, "multline\nending with EOL\n", "type alias", "locale constructor call",
 		"chained locale", "chained po", "chained from func", "from interface",
+		"this is constant testing",
+		"this is variable testing",
+		"some string to translate",
 	}
 
 	if len(translations) != len(data.Domains[defaultDomain].Translations) {

--- a/docs/xgotext.md
+++ b/docs/xgotext.md
@@ -1,36 +1,80 @@
 # xgotext CLI Tool
 
-`xgotext` is a command-line tool designed to help you extract translatable strings from your Go source code and generate or update Gettext PO files.
+`xgotext` extracts translatable strings from Go source code and writes Gettext template (`.pot`) files. It recognizes the getters provided by this module, including calls through imported-package aliases and `gotext.Translator` implementations.
 
-## 1. Installation
-
-Install `xgotext` using `go install`:
+## Installation
 
 ```bash
 go install github.com/leonelquinteros/gotext/cli/xgotext@latest
 ```
 
-## 2. Usage
+## Basic usage
 
-To extract strings from your project and create a new PO file:
+Use `-in` to recursively scan one directory tree. One `.pot` file is created per domain in the output directory.
 
 ```bash
-xgotext -p . -o locales/en_US/default.po
+xgotext -in . -out locales/templates -default default
 ```
 
-### Options:
-- `-p <path>`: The directory path to scan for Go files (default: current directory).
-- `-o <output>`: The output path for the generated PO file.
-- `-d <domain>`: The domain to extract (default: "default").
-- `-k <keyword>`: Add custom keywords to look for (default: `Get`, `GetD`, `GetN`, `GetND`, `GetC`, `GetDC`, `GetNC`, `GetNDC`).
+Use `-pkg-tree` when the target is a Go package and its dependencies should also be considered:
 
-### 3. Example Workflow
+```bash
+xgotext -pkg-tree . -out locales/templates
+```
 
-1.  **Write your Go code** using `gotext.Get("Hello!")`.
-2.  **Run `xgotext`** to generate the initial `en_US/default.po` file.
-3.  **Translate** the PO file into other languages (e.g., `es_AR/default.po`).
-4.  **Update** your translations later as your code changes by re-running `xgotext` with the same output path.
+Exactly one of `-in` and `-pkg-tree` is required.
 
-## 4. How it works
+### Options
 
-`xgotext` parses your Go files looking for function calls that match the default keywords or any custom ones you've specified. It then collects all unique `msgid` and `msgctxt` pairs and writes them to the specified output file, preserving any existing translations if the file already exists.
+| Option | Description |
+| --- | --- |
+| `-in <directory>` | Recursively scan a source directory. |
+| `-pkg-tree <directory>` | Scan a Go package tree, including packages that import gotext. |
+| `-out <directory>` | Directory in which to create `<domain>.pot` files. Required. |
+| `-default <domain>` | Name used for calls without an explicit domain. Defaults to `default`. |
+| `-exclude <directories>` | Comma-separated directory prefixes to skip in `-in` mode. Defaults to `.git`. |
+| `-v` | Print paths/packages while they are processed. |
+
+## Supported calls
+
+The extractor supports `Get`, `GetN`, `GetD`, `GetND`, `GetC`, `GetNC`, `GetDC`, and `GetNDC` on the gotext package, locales, PO objects, and `Translator` values. It extracts the string-valued arguments: message ID, plural ID, domain, and context. Numeric plural counts may remain dynamic.
+
+```go
+gotext.Get("Save")
+gotext.GetN("%d file", "%d files", count)
+gotext.GetD("errors", "Unable to save")
+gotext.GetC("Open", "menu action")
+```
+
+## Constants and variables
+
+String constants are supported, including aliases and constant expressions. Variables are supported when their declaration-time value is statically resolvable and the variable is not assigned a new value before the getter call.
+
+```go
+const saveLabel = "Save"
+const menuContext = "menu action"
+
+var cancelLabel = "Cancel"
+
+gotext.Get(saveLabel)
+gotext.GetC(cancelLabel, menuContext)
+```
+
+For correctness, xgotext deliberately skips a mutable variable after it has been reassigned. For example, this does **not** extract either value:
+
+```go
+label := "Before"
+label = "After"
+gotext.Get(label)
+```
+
+Calls with dynamic strings—such as values returned from functions, environment variables, maps, or user input—are skipped. Use a constant or an unreassigned, literal-initialized variable when a message must be extracted.
+
+## Workflow
+
+1. Write your messages using gotext getters.
+2. Run xgotext to create/update the `.pot` templates.
+3. Create language-specific `.po` files from those templates and translate them.
+4. Re-run xgotext as source messages change, then merge the updated templates with your translation workflow.
+
+`xgotext` records source locations and de-duplicates matching messages within a domain/context.


### PR DESCRIPTION
## Summary

Supersedes #128 and incorporates the original contribution from @githubzhaoqian, plus follow-up fixes, tests, and documentation.

- resolve string constants, aliases, and declaration-time variable values
- preserve identifier-to-value mapping for multi-name declarations
- skip values that are dynamic or reassigned before use
- safely reject unsupported getter arguments without panicking
- cover directory and package-tree extraction paths

## Validation

ok  	github.com/leonelquinteros/gotext	(cached)
?   	github.com/leonelquinteros/gotext/cli/xgotext	[no test files]
?   	github.com/leonelquinteros/gotext/cli/xgotext/fixtures	[no test files]
?   	github.com/leonelquinteros/gotext/cli/xgotext/fixtures/pkg	[no test files]
ok  	github.com/leonelquinteros/gotext/cli/xgotext/parser	(cached)
ok  	github.com/leonelquinteros/gotext/cli/xgotext/parser/dir	(cached)
ok  	github.com/leonelquinteros/gotext/cli/xgotext/parser/pkg-tree	(cached)
ok  	github.com/leonelquinteros/gotext/plurals	(cached)

Closes #128