### PR TITLE
Escape leading and consecutive quotes in `EscapeSpecialCharacters`

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -786,7 +785,18 @@ func (do *Domain) MarshalText() ([]byte, error) {
 
 // EscapeSpecialCharacters escapes special characters in a string
 func EscapeSpecialCharacters(s string) string {
-	s = regexp.MustCompile(`([^\\])(")`).ReplaceAllString(s, "$1\\\"") // Escape non-escaped double quotation marks
+	// Escape non-escaped double quotation marks
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '"' && (i == 0 || s[i-1] != '\\') {
+			b.WriteString(`\"`)
+		} else {
+			b.WriteByte(c)
+		}
+	}
+	s = b.String()
 
 	if strings.Count(s, "\n") == 0 {
 		return s

--- a/domain_test.go
+++ b/domain_test.go
@@ -352,3 +352,35 @@ func TestDomain_SetPluralResolver(t *testing.T) {
 		t.Error("Custom plural resolver failed")
 	}
 }
+
+func TestEscapeSpecialCharacters(t *testing.T) {
+	// Plain string is unchanged.
+	s := EscapeSpecialCharacters("hello world")
+	if s != "hello world" {
+		t.Errorf("Expected 'hello world' but got '%s'", s)
+	}
+
+	// A double quotation mark is escaped.
+	s = EscapeSpecialCharacters(`say "hi" now`)
+	if s != `say \"hi\" now` {
+		t.Errorf("Expected 'say \\\"hi\\\" now' but got '%s'", s)
+	}
+
+	// A double quotation mark at the start of the string is escaped.
+	s = EscapeSpecialCharacters(`"leading`)
+	if s != `\"leading` {
+		t.Errorf("Expected '\\\"leading' but got '%s'", s)
+	}
+
+	// Consecutive double quotation marks are each escaped.
+	s = EscapeSpecialCharacters(`""`)
+	if s != `\"\"` {
+		t.Errorf("Expected '\\\"\\\"' but got '%s'", s)
+	}
+
+	// A double quotation mark preceded by a backslash is left as-is.
+	s = EscapeSpecialCharacters(`say \"hi\"`)
+	if s != `say \"hi\"` {
+		t.Errorf("Expected 'say \\\"hi\\\"' but got '%s'", s)
+	}
+}


### PR DESCRIPTION
## Is this a fix, improvement or something else?

Fix

## What does this change implement/fix?

The regex `([^\\])(")` in `EscapeSpecialCharacters` did not correctly handle double quotes at position 0 in the string, nor consecutive double quotes. See the added tests.

## I have ...

- [x] answered the 2 questions above,
- [ ] discussed this change in an issue,
- [x] included tests to cover this changes.
