### PR TITLE
Update project to Go 1.27

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,24 +11,24 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.25'
-      id: go
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
 
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.27.0'
+      id: go
+
     - name: Get dependencies
       run: |
-        go get -v -u -t -d ./...
+        go mod download
 
     - name: Build package
-      run: go build -v .
+      run: go build -mod=readonly -v .
 
     - name: Test
-      run: go test -v -race ./...
+      run: go test -mod=readonly -v -race ./...
 
     - name: Install xgotext CLI
       run: go install -v github.com/leonelquinteros/gotext/cli/xgotext

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,6 +59,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set up Go
+      if: matrix.language == 'go'
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.27.0'
+
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
     # or others). This is typically only required for manual builds.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.27.0'
         cache: false
       id: go
 
@@ -27,5 +27,4 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: v2.4
-      
+        version: v2.13.0

--- a/cli/xgotext/parser/dir/parser.go
+++ b/cli/xgotext/parser/dir/parser.go
@@ -51,13 +51,25 @@ func ParseDirRec(dirPath string, exclude []string, data *parser.DomainMap, verbo
 	if err != nil {
 		return err
 	}
+	dirPath = filepath.Clean(dirPath)
 
 	excludeDirs := make([]string, 0, len(exclude))
 	for _, excludeDir := range exclude {
-		excludeDir = filepath.Clean(excludeDir)
-		if excludeDir != "." {
-			excludeDirs = append(excludeDirs, excludeDir)
+		if !filepath.IsAbs(excludeDir) {
+			excludeDir = filepath.Join(dirPath, excludeDir)
 		}
+		excludeDir = filepath.Clean(excludeDir)
+
+		// The traversal root is always visited. Exclusions outside the root
+		// cannot match any path WalkDir visits and are ignored.
+		if excludeDir == dirPath {
+			continue
+		}
+		rel, relErr := filepath.Rel(dirPath, excludeDir)
+		if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		excludeDirs = append(excludeDirs, excludeDir)
 	}
 
 	return filepath.WalkDir(dirPath, func(path string, entry fs.DirEntry, err error) error {
@@ -65,14 +77,9 @@ func ParseDirRec(dirPath string, exclude []string, data *parser.DomainMap, verbo
 			return err
 		}
 
-		if entry.IsDir() {
-			subDir, err := filepath.Rel(dirPath, path)
-			if err != nil {
-				return err
-			}
-
+		if entry.IsDir() && entry.Type()&fs.ModeSymlink == 0 {
 			for _, excludeDir := range excludeDirs {
-				if subDir == excludeDir || strings.HasPrefix(subDir, excludeDir+string(filepath.Separator)) {
+				if path == excludeDir || strings.HasPrefix(path, excludeDir+string(filepath.Separator)) {
 					return filepath.SkipDir
 				}
 			}

--- a/cli/xgotext/parser/dir/parser.go
+++ b/cli/xgotext/parser/dir/parser.go
@@ -1,8 +1,8 @@
 package dir
 
 import (
+	"io/fs"
 	"log"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -25,8 +25,15 @@ func AddParser(parser ParseDirFunc) {
 
 // ParseDir calls all known parser for each directory
 func ParseDir(dirPath, basePath string, data *parser.DomainMap) error {
-	dirPath, _ = filepath.Abs(dirPath)
-	basePath, _ = filepath.Abs(basePath)
+	var err error
+	dirPath, err = filepath.Abs(dirPath)
+	if err != nil {
+		return err
+	}
+	basePath, err = filepath.Abs(basePath)
+	if err != nil {
+		return err
+	}
 
 	for _, parser := range knownParser {
 		err := parser(dirPath, basePath, data)
@@ -39,31 +46,45 @@ func ParseDir(dirPath, basePath string, data *parser.DomainMap) error {
 
 // ParseDirRec calls all known parser for each directory
 func ParseDirRec(dirPath string, exclude []string, data *parser.DomainMap, verbose bool) error {
-	dirPath, _ = filepath.Abs(dirPath)
+	var err error
+	dirPath, err = filepath.Abs(dirPath)
+	if err != nil {
+		return err
+	}
 
-	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+	excludeDirs := make([]string, 0, len(exclude))
+	for _, excludeDir := range exclude {
+		excludeDir = filepath.Clean(excludeDir)
+		if excludeDir != "." {
+			excludeDirs = append(excludeDirs, excludeDir)
+		}
+	}
+
+	return filepath.WalkDir(dirPath, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if info.IsDir() {
-			// skip directory if in exclude list
-			subDir, _ := filepath.Rel(dirPath, path)
-			for _, d := range exclude {
-				if strings.HasPrefix(subDir, d) {
-					return nil
+		if entry.IsDir() {
+			subDir, err := filepath.Rel(dirPath, path)
+			if err != nil {
+				return err
+			}
+
+			for _, excludeDir := range excludeDirs {
+				if subDir == excludeDir || strings.HasPrefix(subDir, excludeDir+string(filepath.Separator)) {
+					return filepath.SkipDir
 				}
 			}
+
 			if verbose {
 				log.Print(path)
 			}
 
-			err := ParseDir(path, dirPath, data)
-			if err != nil {
+			if err := ParseDir(path, dirPath, data); err != nil {
 				return err
 			}
 		}
 		return nil
 	})
-	return err
 }

--- a/cli/xgotext/parser/dir/parser_test.go
+++ b/cli/xgotext/parser/dir/parser_test.go
@@ -1,8 +1,10 @@
 package dir
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/leonelquinteros/gotext/cli/xgotext/parser"
@@ -103,6 +105,251 @@ func TestParseDirRec(t *testing.T) {
 	if len(visited) != 3 {
 		t.Errorf("Expected 3 parser calls, got %d", len(visited))
 	}
+}
+
+func TestParseDirRecExclusionSpellings(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	targetChild := filepath.Join(target, "child")
+	sibling := filepath.Join(root, "targeted")
+	for _, path := range []string{targetChild, sibling} {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	exclusions := []string{
+		"target",
+		filepath.Join(".", "target"),
+		filepath.Join("keep", "..", "target"),
+		target,
+		filepath.Join(root, "keep", "..", "target"),
+	}
+	for _, exclusion := range exclusions {
+		t.Run(exclusion, func(t *testing.T) {
+			oldParsers := knownParser
+			t.Cleanup(func() { knownParser = oldParsers })
+
+			visited := make(map[string]bool)
+			knownParser = []ParseDirFunc{func(path, _ string, _ *parser.DomainMap) error {
+				visited[path] = true
+				return nil
+			}}
+
+			if err := ParseDirRec(root, []string{exclusion}, &parser.DomainMap{}, false); err != nil {
+				t.Fatal(err)
+			}
+			if visited[target] || visited[targetChild] {
+				t.Fatalf("exclusion %q visited target directory", exclusion)
+			}
+			if !visited[root] || !visited[sibling] {
+				t.Fatalf("exclusion %q pruned root or prefix sibling", exclusion)
+			}
+		})
+	}
+}
+
+func TestParseDirRecCallbackOrderingAndError(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "child")
+	if err := os.MkdirAll(filepath.Join(child, "nested"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "sibling"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldParsers := knownParser
+	t.Cleanup(func() { knownParser = oldParsers })
+
+	stop := errors.New("stop traversal")
+	events := make([]string, 0, 4)
+	knownParser = []ParseDirFunc{
+		func(path, _ string, _ *parser.DomainMap) error {
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			events = append(events, "first:"+rel)
+			return nil
+		},
+		func(path, _ string, _ *parser.DomainMap) error {
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			events = append(events, "second:"+rel)
+			if path == child {
+				return stop
+			}
+			return nil
+		},
+		func(path, _ string, _ *parser.DomainMap) error {
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			events = append(events, "third:"+rel)
+			return nil
+		},
+	}
+
+	if err := ParseDirRec(root, nil, &parser.DomainMap{}, false); err != stop {
+		t.Fatalf("ParseDirRec error = %v, want %v", err, stop)
+	}
+	want := []string{"first:.", "second:.", "third:.", "first:child", "second:child"}
+	if len(events) != len(want) {
+		t.Fatalf("callback events = %v, want %v", events, want)
+	}
+	for i := range want {
+		if events[i] != want[i] {
+			t.Fatalf("callback events = %v, want %v", events, want)
+		}
+	}
+}
+
+func TestParseDirRecRootCallbackError(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "child"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldParsers := knownParser
+	t.Cleanup(func() { knownParser = oldParsers })
+
+	stop := errors.New("root callback failed")
+	calls := 0
+	knownParser = []ParseDirFunc{func(path, _ string, _ *parser.DomainMap) error {
+		calls++
+		if path == root {
+			return stop
+		}
+		return nil
+	}}
+
+	if err := ParseDirRec(root, nil, &parser.DomainMap{}, false); err != stop {
+		t.Fatalf("ParseDirRec error = %v, want %v", err, stop)
+	}
+	if calls != 1 {
+		t.Fatalf("callback calls after root failure = %d, want 1", calls)
+	}
+}
+
+func TestParseDirRecMissingRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "missing")
+	oldParsers := knownParser
+	t.Cleanup(func() { knownParser = oldParsers })
+
+	called := false
+	knownParser = []ParseDirFunc{func(string, string, *parser.DomainMap) error {
+		called = true
+		return nil
+	}}
+
+	if err := ParseDirRec(root, nil, &parser.DomainMap{}, false); err == nil {
+		t.Fatal("ParseDirRec unexpectedly succeeded for missing root")
+	}
+	if called {
+		t.Fatal("ParseDirRec invoked a callback for a missing root")
+	}
+}
+
+func TestParseDirRecDoesNotFollowSymlink(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	outside := filepath.Join(parent, "outside")
+	if err := os.MkdirAll(filepath.Join(root, "inside"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	outsideChild := filepath.Join(outside, "child")
+	if err := os.MkdirAll(outsideChild, 0755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "outside-link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	oldParsers := knownParser
+	t.Cleanup(func() { knownParser = oldParsers })
+
+	visited := make(map[string]bool)
+	knownParser = []ParseDirFunc{func(path, _ string, _ *parser.DomainMap) error {
+		visited[path] = true
+		return nil
+	}}
+	if err := ParseDirRec(root, nil, &parser.DomainMap{}, false); err != nil {
+		t.Fatal(err)
+	}
+	if visited[link] || visited[outside] || visited[outsideChild] {
+		t.Fatalf("symlink traversal escaped root: %v", visited)
+	}
+	for path := range visited {
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			t.Fatalf("callback outside root: %s", path)
+		}
+	}
+}
+
+func FuzzParseDirRecExcludeNormalization(f *testing.F) {
+	root := f.TempDir()
+	target := filepath.Join(root, "target")
+	targeted := filepath.Join(root, "targeted")
+	for _, path := range []string{filepath.Join(target, "child"), filepath.Join(targeted, "child")} {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			f.Fatal(err)
+		}
+	}
+
+	f.Add("target")
+	f.Add(filepath.Join(".", "target"))
+	f.Add(filepath.Join("keep", "..", "target"))
+	f.Add(target)
+	f.Add(filepath.Join(root, "keep", "..", "target"))
+	f.Add(filepath.Join("..", filepath.Base(root), "target"))
+	f.Add("")
+	f.Add("\x00")
+
+	oldParsers := knownParser
+	f.Cleanup(func() { knownParser = oldParsers })
+
+	f.Fuzz(func(t *testing.T, spelling string) {
+		if len(spelling) > 64*1024 {
+			return
+		}
+		visited := make(map[string]bool)
+		knownParser = []ParseDirFunc{func(path, _ string, _ *parser.DomainMap) error {
+			visited[path] = true
+			return nil
+		}}
+
+		if err := ParseDirRec(root, []string{spelling}, &parser.DomainMap{}, false); err != nil {
+			t.Fatalf("ParseDirRec(%q): %v", spelling, err)
+		}
+		for path := range visited {
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				t.Fatalf("callback outside root for exclusion %q: %s", spelling, path)
+			}
+		}
+
+		normalized := spelling
+		if !filepath.IsAbs(normalized) {
+			normalized = filepath.Join(root, normalized)
+		}
+		if filepath.Clean(normalized) == target {
+			if visited[target] || !visited[targeted] {
+				t.Fatalf("normalized exclusion %q did not prune only target: %v", spelling, visited)
+			}
+		}
+	})
 }
 
 func TestGoFile_InspectFile_Coverage(t *testing.T) {

--- a/cli/xgotext/parser/dir/parser_test.go
+++ b/cli/xgotext/parser/dir/parser_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestAddParser(t *testing.T) {
+	oldParsers := knownParser
+	defer func() { knownParser = oldParsers }()
+
 	initialCount := len(knownParser)
 	AddParser(func(filePath, basePath string, data *parser.DomainMap) error {
 		return nil
@@ -19,6 +22,10 @@ func TestAddParser(t *testing.T) {
 }
 
 func TestParseDir(t *testing.T) {
+	oldParsers := knownParser
+	defer func() { knownParser = oldParsers }()
+	knownParser = nil
+
 	dm := &parser.DomainMap{}
 	called := false
 	AddParser(func(dirPath, basePath string, data *parser.DomainMap) error {
@@ -56,30 +63,45 @@ func TestParseDirRec(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dm := &parser.DomainMap{}
-	callCount := 0
-	AddParser(func(dirPath, basePath string, data *parser.DomainMap) error {
-		callCount++
-		return nil
-	})
+	excludeChild := filepath.Join(excludeDir, "child")
+	err = os.Mkdir(excludeChild, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	// Reset knownParser to only have our test parser for predictable count
+	excludeSibling := filepath.Join(tmpDir, "excluded")
+	err = os.Mkdir(excludeSibling, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	oldParsers := knownParser
-	knownParser = []ParseDirFunc{func(dirPath, basePath string, data *parser.DomainMap) error {
-		callCount++
-		return nil
-	}}
 	defer func() { knownParser = oldParsers }()
 
-	err = ParseDirRec(tmpDir, []string{"exclude"}, dm, true)
+	dm := &parser.DomainMap{}
+	visited := make(map[string]bool)
+	knownParser = []ParseDirFunc{func(dirPath, basePath string, data *parser.DomainMap) error {
+		visited[dirPath] = true
+		return nil
+	}}
+
+	err = ParseDirRec(tmpDir, []string{"", ".", "." + string(filepath.Separator) + "exclude"}, dm, true)
 	if err != nil {
 		t.Errorf("ParseDirRec failed: %v", err)
 	}
 
-	// Should be called for tmpDir and subDir, but not excludeDir
-	// Total 2 calls
-	if callCount != 2 {
-		t.Errorf("Expected 2 calls, got %d", callCount)
+	for _, path := range []string{tmpDir, subDir, excludeSibling} {
+		if !visited[path] {
+			t.Errorf("Expected parser call for %s", path)
+		}
+	}
+	for _, path := range []string{excludeDir, excludeChild} {
+		if visited[path] {
+			t.Errorf("Unexpected parser call for excluded path %s", path)
+		}
+	}
+	if len(visited) != 3 {
+		t.Errorf("Expected 3 parser calls, got %d", len(visited))
 	}
 }
 

--- a/cli/xgotext/parser/dir/parser_test.go
+++ b/cli/xgotext/parser/dir/parser_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/leonelquinteros/gotext/cli/xgotext/parser"
@@ -24,61 +23,46 @@ func TestAddParser(t *testing.T) {
 }
 
 func TestParseDir(t *testing.T) {
-	oldParsers := knownParser
-	defer func() { knownParser = oldParsers }()
-	knownParser = nil
-
+	root := t.TempDir()
 	dm := &parser.DomainMap{}
-	called := false
-	AddParser(func(dirPath, basePath string, data *parser.DomainMap) error {
-		called = true
-		return nil
-	})
 
-	err := ParseDir(".", ".", dm)
-	if err != nil {
-		t.Errorf("ParseDir failed: %v", err)
+	oldParsers := knownParser
+	t.Cleanup(func() { knownParser = oldParsers })
+
+	var gotDir, gotBase string
+	var gotData *parser.DomainMap
+	knownParser = []ParseDirFunc{func(dirPath, basePath string, data *parser.DomainMap) error {
+		gotDir, gotBase, gotData = dirPath, basePath, data
+		return nil
+	}}
+
+	if err := ParseDir(root, root, dm); err != nil {
+		t.Fatalf("ParseDir failed: %v", err)
 	}
-	if !called {
-		t.Error("ParseDir did not call the added parser")
+	if gotDir != root || gotBase != root || gotData != dm {
+		t.Fatalf("ParseDir callback = (%q, %q, %p), want (%q, %q, %p)", gotDir, gotBase, gotData, root, root, dm)
 	}
 }
-
 func TestParseDirRec(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "gotext-test-rec-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.RemoveAll(tmpDir)
-	}()
-
+	tmpDir := t.TempDir()
 	subDir := filepath.Join(tmpDir, "sub")
-	err = os.Mkdir(subDir, 0755)
-	if err != nil {
+	if err := os.Mkdir(subDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 
 	excludeDir := filepath.Join(tmpDir, "exclude")
-	err = os.Mkdir(excludeDir, 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	excludeChild := filepath.Join(excludeDir, "child")
-	err = os.Mkdir(excludeChild, 0755)
-	if err != nil {
+	if err := os.MkdirAll(excludeChild, 0755); err != nil {
 		t.Fatal(err)
 	}
 
 	excludeSibling := filepath.Join(tmpDir, "excluded")
-	err = os.Mkdir(excludeSibling, 0755)
-	if err != nil {
+	if err := os.Mkdir(excludeSibling, 0755); err != nil {
 		t.Fatal(err)
 	}
 
 	oldParsers := knownParser
-	defer func() { knownParser = oldParsers }()
+	t.Cleanup(func() { knownParser = oldParsers })
 
 	dm := &parser.DomainMap{}
 	visited := make(map[string]bool)
@@ -87,23 +71,32 @@ func TestParseDirRec(t *testing.T) {
 		return nil
 	}}
 
-	err = ParseDirRec(tmpDir, []string{"", ".", "." + string(filepath.Separator) + "exclude"}, dm, true)
-	if err != nil {
-		t.Errorf("ParseDirRec failed: %v", err)
+	excludeSpelling := "." + string(filepath.Separator) + "exclude"
+	if err := ParseDirRec(tmpDir, []string{"", ".", excludeSpelling}, dm, false); err != nil {
+		t.Fatalf("ParseDirRec failed: %v", err)
 	}
 
-	for _, path := range []string{tmpDir, subDir, excludeSibling} {
+	assertVisitedDirs(t, visited, []string{tmpDir, subDir, excludeSibling})
+}
+
+func assertVisitedDirs(t *testing.T, visited map[string]bool, want []string) {
+	t.Helper()
+	expected := make(map[string]bool, len(want))
+	for _, path := range want {
+		expected[path] = true
+	}
+	if len(visited) != len(expected) {
+		t.Fatalf("visited directories = %v, want %v", visited, expected)
+	}
+	for path := range expected {
 		if !visited[path] {
-			t.Errorf("Expected parser call for %s", path)
+			t.Errorf("expected parser call for %s", path)
 		}
 	}
-	for _, path := range []string{excludeDir, excludeChild} {
-		if visited[path] {
-			t.Errorf("Unexpected parser call for excluded path %s", path)
+	for path := range visited {
+		if !expected[path] {
+			t.Errorf("unexpected parser call for %s", path)
 		}
-	}
-	if len(visited) != 3 {
-		t.Errorf("Expected 3 parser calls, got %d", len(visited))
 	}
 }
 
@@ -111,22 +104,35 @@ func TestParseDirRecExclusionSpellings(t *testing.T) {
 	root := t.TempDir()
 	target := filepath.Join(root, "target")
 	targetChild := filepath.Join(target, "child")
-	sibling := filepath.Join(root, "targeted")
-	for _, path := range []string{targetChild, sibling} {
+	prefixSibling := filepath.Join(root, "targeted")
+	prefixSiblingChild := filepath.Join(prefixSibling, "child")
+	for _, path := range []string{targetChild, prefixSiblingChild} {
 		if err := os.MkdirAll(path, 0755); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	exclusions := []string{
-		"target",
-		filepath.Join(".", "target"),
-		filepath.Join("keep", "..", "target"),
-		target,
-		filepath.Join(root, "keep", "..", "target"),
+	separator := string(filepath.Separator)
+	allDirs := []string{root, target, targetChild, prefixSibling, prefixSiblingChild}
+	targetExcluded := []string{root, prefixSibling, prefixSiblingChild}
+	cases := []struct {
+		name     string
+		spelling string
+		want     []string
+	}{
+		{name: "relative", spelling: "target", want: targetExcluded},
+		{name: "relative-dot", spelling: "." + separator + "target", want: targetExcluded},
+		{name: "relative-parent", spelling: "keep" + separator + ".." + separator + "target", want: targetExcluded},
+		{name: "absolute", spelling: target, want: targetExcluded},
+		{name: "absolute-parent", spelling: filepath.Join(root, "keep") + separator + ".." + separator + "target", want: targetExcluded},
+		{name: "relative-parent-root", spelling: ".." + separator + filepath.Base(root) + separator + "target", want: targetExcluded},
+		{name: "root-relative", spelling: ".", want: allDirs},
+		{name: "root-absolute", spelling: root, want: allDirs},
+		{name: "outside-root", spelling: ".." + separator + "outside", want: allDirs},
 	}
-	for _, exclusion := range exclusions {
-		t.Run(exclusion, func(t *testing.T) {
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			oldParsers := knownParser
 			t.Cleanup(func() { knownParser = oldParsers })
 
@@ -136,15 +142,10 @@ func TestParseDirRecExclusionSpellings(t *testing.T) {
 				return nil
 			}}
 
-			if err := ParseDirRec(root, []string{exclusion}, &parser.DomainMap{}, false); err != nil {
+			if err := ParseDirRec(root, []string{tc.spelling}, &parser.DomainMap{}, false); err != nil {
 				t.Fatal(err)
 			}
-			if visited[target] || visited[targetChild] {
-				t.Fatalf("exclusion %q visited target directory", exclusion)
-			}
-			if !visited[root] || !visited[sibling] {
-				t.Fatalf("exclusion %q pruned root or prefix sibling", exclusion)
-			}
+			assertVisitedDirs(t, visited, tc.want)
 		})
 	}
 }
@@ -163,33 +164,21 @@ func TestParseDirRecCallbackOrderingAndError(t *testing.T) {
 	t.Cleanup(func() { knownParser = oldParsers })
 
 	stop := errors.New("stop traversal")
-	events := make([]string, 0, 4)
+	events := make([]string, 0, 5)
 	knownParser = []ParseDirFunc{
 		func(path, _ string, _ *parser.DomainMap) error {
-			rel, err := filepath.Rel(root, path)
-			if err != nil {
-				return err
-			}
-			events = append(events, "first:"+rel)
+			events = append(events, "first:"+path)
 			return nil
 		},
 		func(path, _ string, _ *parser.DomainMap) error {
-			rel, err := filepath.Rel(root, path)
-			if err != nil {
-				return err
-			}
-			events = append(events, "second:"+rel)
+			events = append(events, "second:"+path)
 			if path == child {
 				return stop
 			}
 			return nil
 		},
 		func(path, _ string, _ *parser.DomainMap) error {
-			rel, err := filepath.Rel(root, path)
-			if err != nil {
-				return err
-			}
-			events = append(events, "third:"+rel)
+			events = append(events, "third:"+path)
 			return nil
 		},
 	}
@@ -197,7 +186,13 @@ func TestParseDirRecCallbackOrderingAndError(t *testing.T) {
 	if err := ParseDirRec(root, nil, &parser.DomainMap{}, false); err != stop {
 		t.Fatalf("ParseDirRec error = %v, want %v", err, stop)
 	}
-	want := []string{"first:.", "second:.", "third:.", "first:child", "second:child"}
+	want := []string{
+		"first:" + root,
+		"second:" + root,
+		"third:" + root,
+		"first:" + child,
+		"second:" + child,
+	}
 	if len(events) != len(want) {
 		t.Fatalf("callback events = %v, want %v", events, want)
 	}
@@ -218,20 +213,21 @@ func TestParseDirRecRootCallbackError(t *testing.T) {
 	t.Cleanup(func() { knownParser = oldParsers })
 
 	stop := errors.New("root callback failed")
-	calls := 0
-	knownParser = []ParseDirFunc{func(path, _ string, _ *parser.DomainMap) error {
-		calls++
+	calls := make([]string, 0, 1)
+	knownParsers := []ParseDirFunc{func(path, _ string, _ *parser.DomainMap) error {
+		calls = append(calls, path)
 		if path == root {
 			return stop
 		}
 		return nil
 	}}
+	knownParser = knownParsers
 
 	if err := ParseDirRec(root, nil, &parser.DomainMap{}, false); err != stop {
 		t.Fatalf("ParseDirRec error = %v, want %v", err, stop)
 	}
-	if calls != 1 {
-		t.Fatalf("callback calls after root failure = %d, want 1", calls)
+	if len(calls) != 1 || calls[0] != root {
+		t.Fatalf("callback calls after root failure = %v, want [%s]", calls, root)
 	}
 }
 
@@ -258,11 +254,11 @@ func TestParseDirRecDoesNotFollowSymlink(t *testing.T) {
 	parent := t.TempDir()
 	root := filepath.Join(parent, "root")
 	outside := filepath.Join(parent, "outside")
-	if err := os.MkdirAll(filepath.Join(root, "inside"), 0755); err != nil {
+	inside := filepath.Join(root, "inside")
+	if err := os.MkdirAll(inside, 0755); err != nil {
 		t.Fatal(err)
 	}
-	outsideChild := filepath.Join(outside, "child")
-	if err := os.MkdirAll(outsideChild, 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(outside, "child"), 0755); err != nil {
 		t.Fatal(err)
 	}
 	link := filepath.Join(root, "outside-link")
@@ -281,42 +277,40 @@ func TestParseDirRecDoesNotFollowSymlink(t *testing.T) {
 	if err := ParseDirRec(root, nil, &parser.DomainMap{}, false); err != nil {
 		t.Fatal(err)
 	}
-	if visited[link] || visited[outside] || visited[outsideChild] {
-		t.Fatalf("symlink traversal escaped root: %v", visited)
-	}
-	for path := range visited {
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			t.Fatalf("callback outside root: %s", path)
-		}
-	}
+	assertVisitedDirs(t, visited, []string{root, inside})
 }
-
 func FuzzParseDirRecExcludeNormalization(f *testing.F) {
 	root := f.TempDir()
 	target := filepath.Join(root, "target")
+	targetChild := filepath.Join(target, "child")
 	targeted := filepath.Join(root, "targeted")
-	for _, path := range []string{filepath.Join(target, "child"), filepath.Join(targeted, "child")} {
+	targetedChild := filepath.Join(targeted, "child")
+	for _, path := range []string{targetChild, targetedChild} {
 		if err := os.MkdirAll(path, 0755); err != nil {
 			f.Fatal(err)
 		}
 	}
 
+	separator := string(filepath.Separator)
 	f.Add("target")
-	f.Add(filepath.Join(".", "target"))
-	f.Add(filepath.Join("keep", "..", "target"))
+	f.Add("." + separator + "target")
+	f.Add("keep" + separator + ".." + separator + "target")
 	f.Add(target)
-	f.Add(filepath.Join(root, "keep", "..", "target"))
-	f.Add(filepath.Join("..", filepath.Base(root), "target"))
+	f.Add(filepath.Join(root, "keep") + separator + ".." + separator + "target")
+	f.Add(".." + separator + filepath.Base(root) + separator + "target")
 	f.Add("")
 	f.Add("\x00")
 
 	oldParsers := knownParser
 	f.Cleanup(func() { knownParser = oldParsers })
 
+	allowed := map[string]struct{}{
+		root:          {},
+		target:        {},
+		targetChild:   {},
+		targeted:      {},
+		targetedChild: {},
+	}
 	f.Fuzz(func(t *testing.T, spelling string) {
 		if len(spelling) > 64*1024 {
 			return
@@ -330,30 +324,13 @@ func FuzzParseDirRecExcludeNormalization(f *testing.F) {
 		if err := ParseDirRec(root, []string{spelling}, &parser.DomainMap{}, false); err != nil {
 			t.Fatalf("ParseDirRec(%q): %v", spelling, err)
 		}
+		if !visited[root] {
+			t.Fatalf("ParseDirRec(%q) did not visit traversal root", spelling)
+		}
 		for path := range visited {
-			rel, err := filepath.Rel(root, path)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-				t.Fatalf("callback outside root for exclusion %q: %s", spelling, path)
-			}
-		}
-
-		normalized := spelling
-		if !filepath.IsAbs(normalized) {
-			normalized = filepath.Join(root, normalized)
-		}
-		if filepath.Clean(normalized) == target {
-			if visited[target] || !visited[targeted] {
-				t.Fatalf("normalized exclusion %q did not prune only target: %v", spelling, visited)
+			if _, ok := allowed[path]; !ok {
+				t.Fatalf("ParseDirRec(%q) visited unexpected path %s", spelling, path)
 			}
 		}
 	})
-}
-
-func TestGoFile_InspectFile_Coverage(t *testing.T) {
-	// Minimal coverage for the InspectFile switch
-	g := &GoFile{}
-	g.InspectFile(nil) // Default case
 }

--- a/cli/xgotext/parser/domain.go
+++ b/cli/xgotext/parser/domain.go
@@ -18,8 +18,11 @@ type Translation struct {
 
 // AddLocations to translation
 func (t *Translation) AddLocations(locations []string) {
+	if t == nil || len(locations) == 0 {
+		return
+	}
 	if t.SourceLocations == nil {
-		t.SourceLocations = locations
+		t.SourceLocations = append([]string(nil), locations...)
 	} else {
 		t.SourceLocations = append(t.SourceLocations, locations...)
 	}
@@ -27,9 +30,14 @@ func (t *Translation) AddLocations(locations []string) {
 
 // Dump translation as string
 func (t *Translation) Dump() string {
+	if t == nil {
+		return ""
+	}
+
 	data := make([]string, 0, len(t.SourceLocations)+5)
 
-	locations := t.SourceLocations
+	locations := make([]string, len(t.SourceLocations))
+	copy(locations, t.SourceLocations)
 	sort.Strings(locations)
 	for _, location := range locations {
 		data = append(data, "#: "+location)
@@ -110,7 +118,11 @@ func (m TranslationMap) Dump() string {
 
 	data := make([]string, 0, len(m))
 	for _, key := range keys {
-		data = append(data, (m)[key].Dump())
+		if translation := m[key]; translation != nil {
+			if dump := translation.Dump(); dump != "" {
+				data = append(data, dump)
+			}
+		}
 	}
 	return strings.Join(data, "\n\n")
 }
@@ -123,23 +135,28 @@ type Domain struct {
 
 // AddTranslation to the domain
 func (d *Domain) AddTranslation(translation *Translation) {
+	if d == nil || translation == nil {
+		return
+	}
 	if d.Translations == nil {
 		d.Translations = make(TranslationMap)
+	}
+	if d.ContextTranslations == nil {
 		d.ContextTranslations = make(map[string]TranslationMap)
 	}
 
 	if translation.Context == "" {
-		if t, ok := d.Translations[translation.MsgID]; ok {
+		if t, ok := d.Translations[translation.MsgID]; ok && t != nil {
 			t.AddLocations(translation.SourceLocations)
 		} else {
 			d.Translations[translation.MsgID] = translation
 		}
 	} else {
-		if _, ok := d.ContextTranslations[translation.Context]; !ok {
+		if _, ok := d.ContextTranslations[translation.Context]; !ok || d.ContextTranslations[translation.Context] == nil {
 			d.ContextTranslations[translation.Context] = make(TranslationMap)
 		}
 
-		if t, ok := d.ContextTranslations[translation.Context][translation.MsgID]; ok {
+		if t, ok := d.ContextTranslations[translation.Context][translation.MsgID]; ok && t != nil {
 			t.AddLocations(translation.SourceLocations)
 		} else {
 			d.ContextTranslations[translation.Context][translation.MsgID] = translation
@@ -149,8 +166,14 @@ func (d *Domain) AddTranslation(translation *Translation) {
 
 // Dump the domain as string
 func (d *Domain) Dump() string {
+	if d == nil {
+		return ""
+	}
+
 	data := make([]string, 0, len(d.ContextTranslations)+1)
-	data = append(data, d.Translations.Dump())
+	if dump := d.Translations.Dump(); dump != "" {
+		data = append(data, dump)
+	}
 
 	// sort context translations by context for consistence output
 	keys := make([]string, 0, len(d.ContextTranslations))
@@ -160,7 +183,9 @@ func (d *Domain) Dump() string {
 	sort.Strings(keys)
 
 	for _, key := range keys {
-		data = append(data, d.ContextTranslations[key].Dump())
+		if dump := d.ContextTranslations[key].Dump(); dump != "" {
+			data = append(data, dump)
+		}
 	}
 	return strings.Join(data, "\n\n")
 }
@@ -203,6 +228,9 @@ type DomainMap struct {
 
 // AddTranslation to domain map
 func (m *DomainMap) AddTranslation(domain string, translation *Translation) {
+	if m == nil || translation == nil {
+		return
+	}
 	if m.Domains == nil {
 		m.Domains = make(map[string]*Domain, 1)
 	}
@@ -217,7 +245,7 @@ func (m *DomainMap) AddTranslation(domain string, translation *Translation) {
 		domain = m.Default
 	}
 
-	if _, ok := m.Domains[domain]; !ok {
+	if _, ok := m.Domains[domain]; !ok || m.Domains[domain] == nil {
 		m.Domains[domain] = new(Domain)
 	}
 	m.Domains[domain].AddTranslation(translation)
@@ -225,6 +253,9 @@ func (m *DomainMap) AddTranslation(domain string, translation *Translation) {
 
 // Save domains to directory
 func (m *DomainMap) Save(directory string) error {
+	if m == nil {
+		return nil
+	}
 	// ensure output directory exist
 	err := os.MkdirAll(directory, os.ModePerm)
 	if err != nil {
@@ -233,6 +264,9 @@ func (m *DomainMap) Save(directory string) error {
 
 	// save each domain in a separate po file
 	for name, domain := range m.Domains {
+		if domain == nil {
+			continue
+		}
 		err := domain.Save(filepath.Join(directory, name+".pot"))
 		if err != nil {
 			return fmt.Errorf("failed to save domain %s: %v", name, err)

--- a/cli/xgotext/parser/domain_test.go
+++ b/cli/xgotext/parser/domain_test.go
@@ -3,6 +3,8 @@ package parser
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -75,7 +77,7 @@ func TestDomain_AddTranslation(t *testing.T) {
 	if len(d.ContextTranslations["ctx"]) != 1 {
 		t.Error("AddTranslation failed for context")
 	}
-	
+
 	// Add same ID in same context
 	tr4 := &Translation{
 		MsgID:           "test",
@@ -85,6 +87,76 @@ func TestDomain_AddTranslation(t *testing.T) {
 	d.AddTranslation(tr4)
 	if len(d.ContextTranslations["ctx"]["test"].SourceLocations) != 2 {
 		t.Error("AddTranslation failed to merge context locations")
+	}
+}
+
+func TestDomain_AddTranslation_PartialMaps(t *testing.T) {
+	t.Run("translations initialized", func(t *testing.T) {
+		existing := &Translation{MsgID: "existing"}
+		domain := &Domain{
+			Translations: TranslationMap{"existing": existing},
+		}
+		domain.AddTranslation(&Translation{MsgID: "contextual", Context: "ctx"})
+
+		if domain.Translations["existing"] != existing {
+			t.Fatal("existing translations were replaced")
+		}
+		if domain.ContextTranslations["ctx"]["contextual"] == nil {
+			t.Fatal("context translations were not initialized")
+		}
+	})
+
+	t.Run("context translations initialized", func(t *testing.T) {
+		existing := &Translation{MsgID: "existing", Context: "ctx"}
+		domain := &Domain{
+			ContextTranslations: map[string]TranslationMap{
+				"ctx": {"existing": existing},
+			},
+		}
+		domain.AddTranslation(&Translation{MsgID: "uncontextualized"})
+
+		if domain.ContextTranslations["ctx"]["existing"] != existing {
+			t.Fatal("existing context translations were replaced")
+		}
+		if domain.Translations["uncontextualized"] == nil {
+			t.Fatal("translations were not initialized")
+		}
+	})
+}
+
+func TestDomainMap_AddTranslation_CustomDefaultMergesLocations(t *testing.T) {
+	domainMap := &DomainMap{Default: "messages"}
+	domainMap.AddTranslation("", &Translation{
+		MsgID:           "same",
+		SourceLocations: []string{"z.go:4"},
+	})
+	domainMap.AddTranslation("", &Translation{
+		MsgID:           "same",
+		SourceLocations: []string{"a.go:2"},
+	})
+
+	domain := domainMap.Domains["messages"]
+	if domain == nil {
+		t.Fatal("custom default domain was not created")
+	}
+	translation := domain.Translations["same"]
+	if translation == nil {
+		t.Fatal("translation was not added to the custom default domain")
+	}
+	if !reflect.DeepEqual(translation.SourceLocations, []string{"z.go:4", "a.go:2"}) {
+		t.Fatalf("locations = %v, want source order preserved", translation.SourceLocations)
+	}
+}
+
+func TestDomain_Dump_PartialContextMapHasNoEmptyEntry(t *testing.T) {
+	domain := &Domain{
+		ContextTranslations: map[string]TranslationMap{
+			"ctx": {"id": {MsgID: "id", Context: "ctx"}},
+		},
+	}
+	dump := domain.Dump()
+	if strings.HasPrefix(dump, "\n") || !contains(dump, "msgid \"id\"") {
+		t.Fatalf("unexpected partial-domain dump: %q", dump)
 	}
 }
 
@@ -112,7 +184,7 @@ func TestDomainMap_Save(t *testing.T) {
 
 	dm := &DomainMap{}
 	dm.AddTranslation("test", &Translation{MsgID: "msg", SourceLocations: []string{"loc:1"}})
-	
+
 	err = dm.Save(tmpDir)
 	if err != nil {
 		t.Errorf("Save failed: %v", err)
@@ -122,6 +194,38 @@ func TestDomainMap_Save(t *testing.T) {
 	if _, err := os.Stat(potPath); os.IsNotExist(err) {
 		t.Error("pot file was not created")
 	}
+}
+
+func FuzzTranslationDumpPreservesState(f *testing.F) {
+	f.Add("id", "", "", "z.go:4\na.go:2")
+	f.Add("id", "plural", "ctx", "")
+	f.Add("", "", "", `location with "quotes"`)
+
+	f.Fuzz(func(t *testing.T, msgID, msgIDPlural, context, locationData string) {
+		if len(msgID)+len(msgIDPlural)+len(context)+len(locationData) > 64<<10 {
+			return
+		}
+
+		var locations []string
+		if locationData != "" {
+			locations = strings.Split(locationData, "\n")
+		}
+		before := append([]string(nil), locations...)
+		translation := &Translation{
+			MsgID:           msgID,
+			MsgIDPlural:     msgIDPlural,
+			Context:         context,
+			SourceLocations: locations,
+		}
+		firstDump := translation.Dump()
+		secondDump := translation.Dump()
+		if firstDump != secondDump {
+			t.Fatalf("Dump changed across repeated calls: %q != %q", firstDump, secondDump)
+		}
+		if !reflect.DeepEqual(translation.SourceLocations, before) {
+			t.Fatalf("Dump mutated source locations: got %v, want %v", translation.SourceLocations, before)
+		}
+	})
 }
 
 func contains(s, substr string) bool {

--- a/cli/xgotext/parser/domain_test.go
+++ b/cli/xgotext/parser/domain_test.go
@@ -9,104 +9,137 @@ import (
 )
 
 func TestTranslation_AddLocations(t *testing.T) {
-	tr := &Translation{
-		MsgID: "test",
-	}
-	tr.AddLocations([]string{"file1.go:10"})
-	if len(tr.SourceLocations) != 1 {
-		t.Error("AddLocations failed to add to nil slice")
+	tr := &Translation{MsgID: "test"}
+	first := []string{"file1.go:10"}
+	tr.AddLocations(first)
+	first[0] = "caller mutated its input"
+	if !reflect.DeepEqual(tr.SourceLocations, []string{"file1.go:10"}) {
+		t.Fatalf("locations after first append = %v, want copied input", tr.SourceLocations)
 	}
 
 	tr.AddLocations([]string{"file2.go:20"})
-	if len(tr.SourceLocations) != 2 {
-		t.Error("AddLocations failed to append")
+	if !reflect.DeepEqual(tr.SourceLocations, []string{"file1.go:10", "file2.go:20"}) {
+		t.Fatalf("locations after append = %v, want source order preserved", tr.SourceLocations)
+	}
+	before := append([]string(nil), tr.SourceLocations...)
+	tr.AddLocations(nil)
+	if !reflect.DeepEqual(tr.SourceLocations, before) {
+		t.Fatalf("nil append changed locations: got %v, want %v", tr.SourceLocations, before)
 	}
 }
 
 func TestTranslation_Dump(t *testing.T) {
-	tr := &Translation{
-		MsgID:           "test",
-		SourceLocations: []string{"file.go:10"},
-	}
-	dump := tr.Dump()
-	if !contains(dump, "msgid \"test\"") || !contains(dump, "#: file.go:10") {
-		t.Error("Dump failed for simple translation")
+	tests := []struct {
+		name        string
+		translation Translation
+		want        string
+	}{
+		{
+			name:        "sorted references and escaped message",
+			translation: Translation{MsgID: "line \"quoted\"\nnext", SourceLocations: []string{"z.go:4", "a.go:2"}},
+			want: `#: a.go:2
+#: z.go:4
+msgid "line \"quoted\"\nnext"
+msgstr ""`,
+		},
+		{
+			name:        "plural",
+			translation: Translation{MsgID: "test", MsgIDPlural: "tests"},
+			want: `msgid "test"
+msgid_plural "tests"
+msgstr[0] ""
+msgstr[1] ""`,
+		},
+		{
+			name:        "context",
+			translation: Translation{MsgID: "test", Context: "ctx"},
+			want: `msgctxt ctx
+msgid "test"
+msgstr ""`,
+		},
 	}
 
-	tr.MsgIDPlural = "tests"
-	dump = tr.Dump()
-	if !contains(dump, "msgid_plural \"tests\"") || !contains(dump, "msgstr[0] \"\"") {
-		t.Error("Dump failed for plural translation")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			beforeLocations := append([]string(nil), test.translation.SourceLocations...)
+			firstDump := test.translation.Dump()
+			if firstDump != test.want {
+				t.Fatalf("Dump() = %q, want %q", firstDump, test.want)
+			}
+			if secondDump := test.translation.Dump(); secondDump != firstDump {
+				t.Fatalf("Dump() changed across calls: %q != %q", secondDump, firstDump)
+			}
+			if !reflect.DeepEqual(test.translation.SourceLocations, beforeLocations) {
+				t.Fatalf("Dump() mutated source locations: got %v, want %v",
+					test.translation.SourceLocations, beforeLocations)
+			}
+		})
 	}
 
-	tr.Context = "ctx"
-	dump = tr.Dump()
-	if !contains(dump, "msgctxt ctx") {
-		t.Error("Dump failed for context translation")
+	var nilTranslation *Translation
+	if got := nilTranslation.Dump(); got != "" {
+		t.Fatalf("nil Translation.Dump() = %q, want empty output", got)
 	}
 }
 
 func TestDomain_AddTranslation(t *testing.T) {
-	d := &Domain{}
-	tr := &Translation{
+	domain := &Domain{}
+	domain.AddTranslation(&Translation{
 		MsgID:           "test",
 		SourceLocations: []string{"file.go:10"},
-	}
-	d.AddTranslation(tr)
-	if len(d.Translations) != 1 {
-		t.Error("AddTranslation failed")
-	}
-
-	// Add same ID different location
-	tr2 := &Translation{
+	})
+	domain.AddTranslation(&Translation{
 		MsgID:           "test",
 		SourceLocations: []string{"file.go:20"},
+	})
+	translation := domain.Translations["test"]
+	if translation == nil {
+		t.Fatal("uncontextualized translation was not added")
 	}
-	d.AddTranslation(tr2)
-	if len(d.Translations) != 1 || len(d.Translations["test"].SourceLocations) != 2 {
-		t.Error("AddTranslation failed to merge locations")
+	if !reflect.DeepEqual(translation.SourceLocations, []string{"file.go:10", "file.go:20"}) {
+		t.Fatalf("uncontextualized locations = %v, want merged source order", translation.SourceLocations)
 	}
 
-	// Add with context
-	tr3 := &Translation{
+	domain.AddTranslation(&Translation{
 		MsgID:           "test",
 		Context:         "ctx",
 		SourceLocations: []string{"file.go:30"},
-	}
-	d.AddTranslation(tr3)
-	if len(d.ContextTranslations["ctx"]) != 1 {
-		t.Error("AddTranslation failed for context")
-	}
-
-	// Add same ID in same context
-	tr4 := &Translation{
+	})
+	domain.AddTranslation(&Translation{
 		MsgID:           "test",
 		Context:         "ctx",
 		SourceLocations: []string{"file.go:40"},
+	})
+	contextual := domain.ContextTranslations["ctx"]["test"]
+	if contextual == nil {
+		t.Fatal("contextual translation was not added")
 	}
-	d.AddTranslation(tr4)
-	if len(d.ContextTranslations["ctx"]["test"].SourceLocations) != 2 {
-		t.Error("AddTranslation failed to merge context locations")
+	if contextual.MsgID != "test" || contextual.Context != "ctx" ||
+		!reflect.DeepEqual(contextual.SourceLocations, []string{"file.go:30", "file.go:40"}) {
+		t.Fatalf("contextual translation = %#v, want merged context metadata", contextual)
+	}
+	if len(domain.Translations) != 1 || len(domain.ContextTranslations) != 1 {
+		t.Fatalf("domain maps = %#v/%#v, want one entry in each map",
+			domain.Translations, domain.ContextTranslations)
 	}
 }
 
 func TestDomain_AddTranslation_PartialMaps(t *testing.T) {
-	t.Run("translations initialized", func(t *testing.T) {
+	t.Run("contextual insertion preserves initialized translations", func(t *testing.T) {
 		existing := &Translation{MsgID: "existing"}
-		domain := &Domain{
-			Translations: TranslationMap{"existing": existing},
-		}
+		domain := &Domain{Translations: TranslationMap{"existing": existing}}
 		domain.AddTranslation(&Translation{MsgID: "contextual", Context: "ctx"})
 
 		if domain.Translations["existing"] != existing {
 			t.Fatal("existing translations were replaced")
 		}
-		if domain.ContextTranslations["ctx"]["contextual"] == nil {
-			t.Fatal("context translations were not initialized")
+		translation := domain.ContextTranslations["ctx"]["contextual"]
+		if translation == nil || translation.MsgID != "contextual" || translation.Context != "ctx" {
+			t.Fatalf("contextual insertion = %#v, want initialized translation", translation)
 		}
 	})
 
-	t.Run("context translations initialized", func(t *testing.T) {
+	t.Run("uncontextualized insertion preserves initialized contexts", func(t *testing.T) {
 		existing := &Translation{MsgID: "existing", Context: "ctx"}
 		domain := &Domain{
 			ContextTranslations: map[string]TranslationMap{
@@ -118,8 +151,31 @@ func TestDomain_AddTranslation_PartialMaps(t *testing.T) {
 		if domain.ContextTranslations["ctx"]["existing"] != existing {
 			t.Fatal("existing context translations were replaced")
 		}
-		if domain.Translations["uncontextualized"] == nil {
-			t.Fatal("translations were not initialized")
+		translation := domain.Translations["uncontextualized"]
+		if translation == nil || translation.MsgID != "uncontextualized" || translation.Context != "" {
+			t.Fatalf("uncontextualized insertion = %#v, want initialized translation", translation)
+		}
+	})
+
+	t.Run("nil context bucket is initialized", func(t *testing.T) {
+		domain := &Domain{
+			ContextTranslations: map[string]TranslationMap{"ctx": nil},
+		}
+		domain.AddTranslation(&Translation{MsgID: "id", Context: "ctx"})
+
+		translation := domain.ContextTranslations["ctx"]["id"]
+		if translation == nil || translation.MsgID != "id" || translation.Context != "ctx" {
+			t.Fatalf("nil context bucket insertion = %#v, want translation", translation)
+		}
+	})
+
+	t.Run("nil existing entry is replaced", func(t *testing.T) {
+		domain := &Domain{Translations: TranslationMap{"id": nil}}
+		domain.AddTranslation(&Translation{MsgID: "id"})
+
+		translation := domain.Translations["id"]
+		if translation == nil || translation.MsgID != "id" {
+			t.Fatalf("nil existing entry = %#v, want replacement translation", translation)
 		}
 	})
 }
@@ -148,28 +204,60 @@ func TestDomainMap_AddTranslation_CustomDefaultMergesLocations(t *testing.T) {
 	}
 }
 
-func TestDomain_Dump_PartialContextMapHasNoEmptyEntry(t *testing.T) {
+func TestDomain_Dump_PartialMaps(t *testing.T) {
 	domain := &Domain{
+		Translations: TranslationMap{"ignored": nil},
 		ContextTranslations: map[string]TranslationMap{
-			"ctx": {"id": {MsgID: "id", Context: "ctx"}},
+			"empty":     nil,
+			"ctx":       {"id": {MsgID: "id", Context: "ctx", SourceLocations: []string{"z.go:2", "a.go:1"}}},
+			"nil-entry": {"ignored": nil},
 		},
 	}
-	dump := domain.Dump()
-	if strings.HasPrefix(dump, "\n") || !contains(dump, "msgid \"id\"") {
-		t.Fatalf("unexpected partial-domain dump: %q", dump)
+	beforeLocations := append([]string(nil), domain.ContextTranslations["ctx"]["id"].SourceLocations...)
+	want := `#: a.go:1
+#: z.go:2
+msgctxt ctx
+msgid "id"
+msgstr ""`
+
+	firstDump := domain.Dump()
+	if firstDump != want {
+		t.Fatalf("Dump() = %q, want %q", firstDump, want)
+	}
+	if secondDump := domain.Dump(); secondDump != firstDump {
+		t.Fatalf("Dump() changed across calls: %q != %q", secondDump, firstDump)
+	}
+	if !reflect.DeepEqual(domain.ContextTranslations["ctx"]["id"].SourceLocations, beforeLocations) {
+		t.Fatalf("Dump() mutated nested source locations: got %v, want %v",
+			domain.ContextTranslations["ctx"]["id"].SourceLocations, beforeLocations)
+	}
+	if strings.HasPrefix(firstDump, "\n") || strings.HasSuffix(firstDump, "\n\n") {
+		t.Fatalf("partial maps introduced empty dump entries: %q", firstDump)
 	}
 }
 
 func TestDomainMap_AddTranslation(t *testing.T) {
-	dm := &DomainMap{}
-	dm.AddTranslation("dom1", &Translation{MsgID: "test1"})
-	if len(dm.Domains["dom1"].Translations) != 1 {
-		t.Error("DomainMap.AddTranslation failed")
-	}
+	domainMap := &DomainMap{}
+	domainMap.AddTranslation("dom1", &Translation{MsgID: "test1"})
+	domainMap.AddTranslation("", &Translation{MsgID: "test_default"})
 
-	dm.AddTranslation("", &Translation{MsgID: "test_default"})
-	if len(dm.Domains["default"].Translations) != 1 {
-		t.Error("DomainMap.AddTranslation failed for default domain")
+	if domainMap.Default != "default" {
+		t.Fatalf("Default = %q, want default", domainMap.Default)
+	}
+	domain := domainMap.Domains["dom1"]
+	if domain == nil || domain.Translations["test1"] == nil {
+		t.Fatal("named domain translation was not added")
+	}
+	defaultDomain := domainMap.Domains["default"]
+	if defaultDomain == nil {
+		t.Fatal("default domain was not created")
+	}
+	translation := defaultDomain.Translations["test_default"]
+	if translation == nil || translation.MsgID != "test_default" || translation.Context != "" {
+		t.Fatalf("default translation = %#v, want literal metadata", translation)
+	}
+	if len(domainMap.Domains) != 2 {
+		t.Fatalf("got %d domains, want two", len(domainMap.Domains))
 	}
 }
 
@@ -182,17 +270,32 @@ func TestDomainMap_Save(t *testing.T) {
 		_ = os.RemoveAll(tmpDir)
 	}()
 
-	dm := &DomainMap{}
-	dm.AddTranslation("test", &Translation{MsgID: "msg", SourceLocations: []string{"loc:1"}})
+	domainMap := &DomainMap{}
+	domainMap.AddTranslation("test", &Translation{
+		MsgID:           "msg",
+		SourceLocations: []string{"loc:1"},
+	})
 
-	err = dm.Save(tmpDir)
-	if err != nil {
-		t.Errorf("Save failed: %v", err)
+	if err := domainMap.Save(tmpDir); err != nil {
+		t.Fatal(err)
 	}
 
 	potPath := filepath.Join(tmpDir, "test.pot")
-	if _, err := os.Stat(potPath); os.IsNotExist(err) {
-		t.Error("pot file was not created")
+	data, err := os.ReadFile(potPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	for _, expected := range []string{
+		`msgid ""`,
+		`"Content-Type: text/plain; charset=UTF-8\n"`,
+		"#: loc:1",
+		`msgid "msg"`,
+		`msgstr ""`,
+	} {
+		if !strings.Contains(content, expected) {
+			t.Errorf("saved domain is missing %q: %q", expected, content)
+		}
 	}
 }
 
@@ -210,24 +313,24 @@ func FuzzTranslationDumpPreservesState(f *testing.F) {
 		if locationData != "" {
 			locations = strings.Split(locationData, "\n")
 		}
-		before := append([]string(nil), locations...)
 		translation := &Translation{
 			MsgID:           msgID,
 			MsgIDPlural:     msgIDPlural,
 			Context:         context,
 			SourceLocations: locations,
 		}
+		before := *translation
+		before.SourceLocations = append([]string(nil), locations...)
+
 		firstDump := translation.Dump()
-		secondDump := translation.Dump()
-		if firstDump != secondDump {
-			t.Fatalf("Dump changed across repeated calls: %q != %q", firstDump, secondDump)
+		if firstDump == "" {
+			t.Fatal("Dump returned empty output for a non-nil translation")
 		}
-		if !reflect.DeepEqual(translation.SourceLocations, before) {
-			t.Fatalf("Dump mutated source locations: got %v, want %v", translation.SourceLocations, before)
+		if secondDump := translation.Dump(); secondDump != firstDump {
+			t.Fatalf("Dump changed across calls: %q != %q", secondDump, firstDump)
+		}
+		if !reflect.DeepEqual(*translation, before) {
+			t.Fatalf("Dump mutated translation: got %#v, want %#v", *translation, before)
 		}
 	})
-}
-
-func contains(s, substr string) bool {
-	return (len(s) >= len(substr)) && (s[0:len(substr)] == substr || contains(s[1:], substr))
 }

--- a/cli/xgotext/parser/gofile.go
+++ b/cli/xgotext/parser/gofile.go
@@ -21,6 +21,8 @@ type GetterDef struct {
 	Domain  int
 }
 
+const gotextPackagePath = "github.com/leonelquinteros/gotext"
+
 // MaxArgIndex returns the largest argument index
 func (d *GetterDef) MaxArgIndex() int {
 	return max(d.ID, d.Plural, d.Context, d.Domain)
@@ -52,26 +54,31 @@ type GoFile struct {
 
 // GetType from ident object
 func (g *GoFile) GetType(ident *ast.Ident) types.Object {
-	for _, pkg := range g.ImportedPackages {
-		if pkg.TypesInfo == nil {
-			continue
-		}
-		if obj, ok := pkg.TypesInfo.Uses[ident]; ok {
-			return obj
-		}
-	}
-	return nil
+	return g.getObject(ident)
 }
 
 // getExprType from any expression
 func (g *GoFile) getExprType(expr ast.Expr) types.Type {
+	if g == nil || expr == nil {
+		return nil
+	}
+
 	for _, pkg := range g.ImportedPackages {
-		if pkg.TypesInfo == nil {
+		if pkg == nil || pkg.TypesInfo == nil {
 			continue
 		}
 		if tv, ok := pkg.TypesInfo.Types[expr]; ok {
 			return tv.Type
 		}
+	}
+
+	if ident, ok := expr.(*ast.Ident); ok {
+		if object := g.getObject(ident); object != nil {
+			return object.Type()
+		}
+	}
+	if paren, ok := expr.(*ast.ParenExpr); ok {
+		return g.getExprType(paren.X)
 	}
 	return nil
 }
@@ -87,68 +94,157 @@ func (g *GoFile) CheckType(rawType types.Type) bool {
 		return g.CheckType(t.Elem())
 
 	case *types.Named:
-		if t.Obj().Pkg() == nil || t.Obj().Pkg().Path() != "github.com/leonelquinteros/gotext" {
-			return false
-		}
+		object := t.Obj()
+		return object != nil && object.Pkg() != nil && object.Pkg().Path() == gotextPackagePath
 
 	case *types.Alias:
 		return g.CheckType(t.Rhs())
 
 	case *types.Interface:
-		// Check if it's the Translator interface from our package
-		// This is used for interfaces like 'Translator'
-		return t.NumMethods() > 0 && t.Method(0).Pkg() != nil && t.Method(0).Pkg().Path() == "github.com/leonelquinteros/gotext"
+		if t.NumMethods() == 0 {
+			return false
+		}
+		for idx := range t.NumMethods() {
+			method := t.Method(idx)
+			if method.Pkg() == nil || method.Pkg().Path() != gotextPackagePath {
+				return false
+			}
+		}
+		return true
 
 	default:
 		return false
 	}
-	return true
 }
 
 // InspectCallExpr inspects the call expression
 func (g *GoFile) InspectCallExpr(n *ast.CallExpr) {
-	// must be a selector expression otherwise it is a local function call
-	expr, ok := n.Fun.(*ast.SelectorExpr)
-	if !ok {
+	if g == nil || n == nil {
 		return
 	}
 
-	// Resolve the type of the receiver (expr.X)
-	receiverType := g.getExprType(expr.X)
-	if receiverType == nil {
-		// Fallback for package calls if types didn't resolve it
-		if id, ok := expr.X.(*ast.Ident); ok && id.Obj == nil {
-			pkg, ok := g.ImportedPackages[id.Name]
-			if !ok || pkg.PkgPath != "github.com/leonelquinteros/gotext" {
-				return
-			}
-		} else {
+	var name string
+	var object types.Object
+	switch fun := n.Fun.(type) {
+	case *ast.Ident:
+		name = fun.Name
+		if _, ok := gotextGetter[name]; !ok {
 			return
 		}
-	} else if !g.CheckType(receiverType) {
+		object = g.getObject(fun)
+		if object != nil {
+			if !isGotextGetterObject(object, name) {
+				return
+			}
+		} else if !g.isGotextDotImport(fun) {
+			return
+		}
+
+	case *ast.SelectorExpr:
+		if fun.Sel == nil {
+			return
+		}
+		name = fun.Sel.Name
+		if _, ok := gotextGetter[name]; !ok {
+			return
+		}
+		object = g.selectorObject(fun)
+		if object != nil {
+			if !isGotextGetterObject(object, name) {
+				return
+			}
+			if signature, ok := object.Type().(*types.Signature); ok && signature.Recv() != nil {
+				if receiverType := g.getExprType(fun.X); receiverType != nil && !g.CheckType(receiverType) {
+					return
+				}
+			}
+		} else if receiverType := g.getExprType(fun.X); receiverType != nil {
+			if !g.CheckType(receiverType) {
+				return
+			}
+		} else if !g.isGotextPackageSelector(fun) {
+			return
+		}
+
+	default:
 		return
 	}
 
-	// convert args
 	args := make([]*ast.BasicLit, len(n.Args))
 	resolving := make(map[types.Object]bool)
 	for idx, arg := range n.Args {
 		args[idx] = g.resolveStringLiteral(arg, n.Pos(), resolving)
 	}
 
-	// get position
-	path, _ := filepath.Rel(g.BasePath, g.FilePath)
-	position := fmt.Sprintf("%s:%d", path, g.FileSet.Position(n.Lparen).Line)
+	g.ParseGetter(gotextGetter[name], args, g.callPosition(n))
+}
 
-	// handle getters
-	if def, ok := gotextGetter[expr.Sel.String()]; ok {
-		g.ParseGetter(def, args, position)
-		return
+func isGotextGetterObject(object types.Object, name string) bool {
+	function, ok := object.(*types.Func)
+	return ok && function.Name() == name && function.Pkg() != nil && function.Pkg().Path() == gotextPackagePath
+}
+
+func (g *GoFile) selectorObject(expr *ast.SelectorExpr) types.Object {
+	if g == nil || expr == nil || expr.Sel == nil {
+		return nil
 	}
+	for _, pkg := range g.ImportedPackages {
+		if pkg == nil || pkg.TypesInfo == nil {
+			continue
+		}
+		if selection := pkg.TypesInfo.Selections[expr]; selection != nil && selection.Obj() != nil {
+			return selection.Obj()
+		}
+		if object := pkg.TypesInfo.Uses[expr.Sel]; object != nil {
+			return object
+		}
+	}
+	return nil
+}
+
+func (g *GoFile) isGotextPackageSelector(expr *ast.SelectorExpr) bool {
+	if g == nil || expr == nil {
+		return false
+	}
+	ident, ok := expr.X.(*ast.Ident)
+	if !ok || ident.Obj != nil {
+		return false
+	}
+	pkg, ok := g.ImportedPackages[ident.Name]
+	return ok && pkg != nil && pkg.PkgPath == gotextPackagePath
+}
+
+func (g *GoFile) isGotextDotImport(ident *ast.Ident) bool {
+	if g == nil || ident == nil || ident.Obj != nil {
+		return false
+	}
+	pkg, ok := g.ImportedPackages["."]
+	return ok && pkg != nil && pkg.PkgPath == gotextPackagePath
+}
+
+func (g *GoFile) callPosition(n *ast.CallExpr) string {
+	if g == nil || n == nil {
+		return ""
+	}
+	path := g.FilePath
+	if g.BasePath != "" && path != "" {
+		if relative, err := filepath.Rel(g.BasePath, path); err == nil {
+			path = relative
+		}
+	}
+	line := 0
+	if g.FileSet != nil {
+		line = g.FileSet.Position(n.Lparen).Line
+	}
+	return fmt.Sprintf("%s:%d", path, line)
 }
 
 // ParseGetter parses the getter function
 func (g *GoFile) ParseGetter(def GetterDef, args []*ast.BasicLit, pos string) {
+	if g == nil || g.Data == nil {
+		return
+	}
+
 	// check if enough arguments are given
 	if len(args) <= def.MaxArgIndex() {
 		return
@@ -174,7 +270,7 @@ func (g *GoFile) ParseGetter(def GetterDef, args []*ast.BasicLit, pos string) {
 		MsgID:           msgID,
 		SourceLocations: []string{pos},
 	}
-	if def.Plural > 0 {
+	if def.Plural != -1 {
 		// plural ID must be a string
 		msgIDPlural, ok := getStringArgument(args, def.Plural, "plural", pos)
 		if !ok {
@@ -182,7 +278,7 @@ func (g *GoFile) ParseGetter(def GetterDef, args []*ast.BasicLit, pos string) {
 		}
 		trans.MsgIDPlural = msgIDPlural
 	}
-	if def.Context > 0 {
+	if def.Context != -1 {
 		// Context must be a string
 		if !isStringArgument(args, def.Context, "context", pos) {
 			return
@@ -215,38 +311,113 @@ func isStringArgument(args []*ast.BasicLit, index int, name, pos string) bool {
 }
 
 func (g *GoFile) resolveStringLiteral(expr ast.Expr, before token.Pos, resolving map[types.Object]bool) *ast.BasicLit {
-	if literal, ok := expr.(*ast.BasicLit); ok && literal.Kind == token.STRING {
-		return literal
+	if g == nil || expr == nil {
+		return nil
+	}
+	if resolving == nil {
+		resolving = make(map[types.Object]bool)
+	}
+	return g.resolveStringLiteralState(expr, before, resolving, make(map[ast.Expr]bool))
+}
+
+func (g *GoFile) resolveStringLiteralState(
+	expr ast.Expr,
+	before token.Pos,
+	resolving map[types.Object]bool,
+	resolvingExpr map[ast.Expr]bool,
+) *ast.BasicLit {
+	if g == nil || expr == nil {
+		return nil
+	}
+
+	switch literal := expr.(type) {
+	case *ast.BasicLit:
+		if literal != nil && literal.Kind == token.STRING {
+			return literal
+		}
+		return nil
 	}
 
 	if literal := g.constantStringLiteral(expr); literal != nil {
 		return literal
 	}
-
-	ident, ok := expr.(*ast.Ident)
-	if !ok || ident.Obj == nil {
+	if resolvingExpr[expr] {
 		return nil
 	}
-	object := g.getObject(ident)
-	if object != nil {
-		if resolving[object] || g.isMutatedBefore(object, before) {
+	resolvingExpr[expr] = true
+	defer delete(resolvingExpr, expr)
+
+	switch value := expr.(type) {
+	case *ast.ParenExpr:
+		if value == nil {
 			return nil
 		}
-		resolving[object] = true
-		defer delete(resolving, object)
-	}
+		return g.resolveStringLiteralState(value.X, before, resolving, resolvingExpr)
 
-	switch decl := ident.Obj.Decl.(type) {
-	case *ast.ValueSpec:
-		for i, name := range decl.Names {
-			if name.Name == ident.Name && i < len(decl.Values) {
-				return g.resolveStringLiteral(decl.Values[i], decl.Pos(), resolving)
+	case *ast.BinaryExpr:
+		if value == nil || value.Op != token.ADD {
+			return nil
+		}
+		left := g.resolveStringLiteralState(value.X, before, resolving, resolvingExpr)
+		right := g.resolveStringLiteralState(value.Y, before, resolving, resolvingExpr)
+		if left == nil || right == nil {
+			return nil
+		}
+		leftValue, leftErr := strconv.Unquote(left.Value)
+		rightValue, rightErr := strconv.Unquote(right.Value)
+		if leftErr != nil || rightErr != nil {
+			return nil
+		}
+		return &ast.BasicLit{
+			Kind:  token.STRING,
+			Value: strconv.Quote(leftValue + rightValue),
+		}
+
+	case *ast.Ident:
+		if value == nil {
+			return nil
+		}
+		object := g.getObject(value)
+		if object != nil {
+			if resolving[object] || g.isMutatedBefore(object, before) {
+				return nil
+			}
+			if constant, ok := object.(*types.Const); ok {
+				return literalFromConstantValue(constant.Val())
+			}
+			resolving[object] = true
+			defer delete(resolving, object)
+		}
+
+		if value.Obj != nil {
+			switch declaration := value.Obj.Decl.(type) {
+			case *ast.ValueSpec:
+				for idx, name := range declaration.Names {
+					if name.Name == value.Name && idx < len(declaration.Values) {
+						return g.resolveStringLiteralState(
+							declaration.Values[idx],
+							declaration.Pos(),
+							resolving,
+							resolvingExpr,
+						)
+					}
+				}
+			case *ast.AssignStmt:
+				for idx, lhs := range declaration.Lhs {
+					if id, ok := lhs.(*ast.Ident); ok && id.Name == value.Name && idx < len(declaration.Rhs) {
+						return g.resolveStringLiteralState(
+							declaration.Rhs[idx],
+							declaration.Pos(),
+							resolving,
+							resolvingExpr,
+						)
+					}
+				}
 			}
 		}
-	case *ast.AssignStmt:
-		for i, lhs := range decl.Lhs {
-			if id, ok := lhs.(*ast.Ident); ok && id.Name == ident.Name && i < len(decl.Rhs) {
-				return g.resolveStringLiteral(decl.Rhs[i], decl.Pos(), resolving)
+		if object != nil {
+			if declaration, declarationPos, ok := g.declarationForObject(object); ok {
+				return g.resolveStringLiteralState(declaration, declarationPos, resolving, resolvingExpr)
 			}
 		}
 	}
@@ -259,24 +430,103 @@ func getLiteralFromIdent(ident *ast.Ident) *ast.BasicLit {
 	return (&GoFile{}).resolveStringLiteral(ident, token.NoPos, make(map[types.Object]bool))
 }
 
+func literalFromConstantValue(value constant.Value) *ast.BasicLit {
+	if value == nil || value.Kind() != constant.String {
+		return nil
+	}
+	return &ast.BasicLit{Kind: token.STRING, Value: strconv.Quote(constant.StringVal(value))}
+}
+
 func (g *GoFile) constantStringLiteral(expr ast.Expr) *ast.BasicLit {
+	if g == nil || expr == nil {
+		return nil
+	}
 	for _, pkg := range g.ImportedPackages {
-		if pkg.TypesInfo == nil {
+		if pkg == nil || pkg.TypesInfo == nil {
 			continue
 		}
-		if value, ok := pkg.TypesInfo.Types[expr]; ok && value.Value != nil && value.Value.Kind() == constant.String {
-			return &ast.BasicLit{Kind: token.STRING, Value: strconv.Quote(constant.StringVal(value.Value))}
+		if value, ok := pkg.TypesInfo.Types[expr]; ok {
+			if literal := literalFromConstantValue(value.Value); literal != nil {
+				return literal
+			}
+		}
+	}
+	if ident, ok := expr.(*ast.Ident); ok {
+		if object := g.getObject(ident); object != nil {
+			if constant, ok := object.(*types.Const); ok {
+				return literalFromConstantValue(constant.Val())
+			}
 		}
 	}
 	return nil
 }
 
-func (g *GoFile) getObject(ident *ast.Ident) types.Object {
+func packageOwnsObject(pkg *packages.Package, object types.Object) bool {
+	if pkg == nil || object == nil {
+		return false
+	}
+	owner := object.Pkg()
+	return owner != nil && pkg.PkgPath == owner.Path()
+}
+
+func (g *GoFile) declarationForObject(object types.Object) (ast.Expr, token.Pos, bool) {
+	if g == nil || object == nil {
+		return nil, token.NoPos, false
+	}
 	for _, pkg := range g.ImportedPackages {
-		if pkg.TypesInfo == nil {
+		if !packageOwnsObject(pkg, object) || pkg.TypesInfo == nil {
+			continue
+		}
+		for _, file := range pkg.Syntax {
+			if file == nil {
+				continue
+			}
+			var declaration ast.Expr
+			var declarationPos token.Pos
+			ast.Inspect(file, func(node ast.Node) bool {
+				if declaration != nil {
+					return false
+				}
+				switch node := node.(type) {
+				case *ast.ValueSpec:
+					for idx, name := range node.Names {
+						if pkg.TypesInfo.Defs[name] == object && idx < len(node.Values) {
+							declaration = node.Values[idx]
+							declarationPos = node.Pos()
+							return false
+						}
+					}
+				case *ast.AssignStmt:
+					for idx, lhs := range node.Lhs {
+						if id, ok := lhs.(*ast.Ident); ok && pkg.TypesInfo.Defs[id] == object && idx < len(node.Rhs) {
+							declaration = node.Rhs[idx]
+							declarationPos = node.Pos()
+							return false
+						}
+					}
+				}
+				return true
+			})
+			if declaration != nil {
+				return declaration, declarationPos, true
+			}
+		}
+	}
+	return nil, token.NoPos, false
+}
+
+func (g *GoFile) getObject(ident *ast.Ident) types.Object {
+	if g == nil || ident == nil {
+		return nil
+	}
+	for _, pkg := range g.ImportedPackages {
+		if pkg == nil || pkg.TypesInfo == nil {
 			continue
 		}
 		if object := pkg.TypesInfo.Uses[ident]; object != nil {
+			return object
+		}
+		if object := pkg.TypesInfo.Defs[ident]; object != nil {
 			return object
 		}
 	}
@@ -285,24 +535,60 @@ func (g *GoFile) getObject(ident *ast.Ident) types.Object {
 
 // isMutatedBefore reports whether a variable has been assigned a new value before its use.
 func (g *GoFile) isMutatedBefore(object types.Object, before token.Pos) bool {
+	if g == nil {
+		return false
+	}
 	if _, ok := object.(*types.Var); !ok {
 		return false
 	}
 
 	for _, pkg := range g.ImportedPackages {
-		if pkg.TypesInfo == nil {
+		if !packageOwnsObject(pkg, object) || pkg.TypesInfo == nil {
 			continue
 		}
 		for _, file := range pkg.Syntax {
+			if file == nil {
+				continue
+			}
 			for node := range ast.Preorder(file) {
-				assign, ok := node.(*ast.AssignStmt)
-				if !ok || assign.Pos() >= before {
-					continue
-				}
-				for _, lhs := range assign.Lhs {
-					ident, ok := lhs.(*ast.Ident)
-					if ok && pkg.TypesInfo.Uses[ident] == object {
+				switch node := node.(type) {
+				case *ast.AssignStmt:
+					if node.Pos() >= before {
+						continue
+					}
+					for _, lhs := range node.Lhs {
+						if ident, ok := lhs.(*ast.Ident); ok && pkg.TypesInfo.Uses[ident] == object {
+							return true
+						}
+					}
+
+				case *ast.IncDecStmt:
+					if node.Pos() >= before {
+						continue
+					}
+					if ident, ok := node.X.(*ast.Ident); ok && pkg.TypesInfo.Uses[ident] == object {
 						return true
+					}
+
+				case *ast.RangeStmt:
+					if node.Body == nil || node.Body.Pos() >= before {
+						continue
+					}
+					for _, candidate := range []ast.Expr{node.Key, node.Value} {
+						ident, ok := candidate.(*ast.Ident)
+						if !ok {
+							continue
+						}
+						switch node.Tok {
+						case token.DEFINE:
+							if pkg.TypesInfo.Defs[ident] == object {
+								return true
+							}
+						case token.ASSIGN:
+							if pkg.TypesInfo.Uses[ident] == object {
+								return true
+							}
+						}
 					}
 				}
 			}

--- a/cli/xgotext/parser/gofile.go
+++ b/cli/xgotext/parser/gofile.go
@@ -131,8 +131,9 @@ func (g *GoFile) InspectCallExpr(n *ast.CallExpr) {
 
 	// convert args
 	args := make([]*ast.BasicLit, len(n.Args))
+	resolving := make(map[types.Object]bool)
 	for idx, arg := range n.Args {
-		args[idx] = g.resolveStringLiteral(arg, n.Pos(), make(map[types.Object]bool))
+		args[idx] = g.resolveStringLiteral(arg, n.Pos(), resolving)
 	}
 
 	// get position
@@ -293,23 +294,17 @@ func (g *GoFile) isMutatedBefore(object types.Object, before token.Pos) bool {
 			continue
 		}
 		for _, file := range pkg.Syntax {
-			mutated := false
-			ast.Inspect(file, func(node ast.Node) bool {
+			for node := range ast.Preorder(file) {
 				assign, ok := node.(*ast.AssignStmt)
 				if !ok || assign.Pos() >= before {
-					return true
+					continue
 				}
 				for _, lhs := range assign.Lhs {
 					ident, ok := lhs.(*ast.Ident)
 					if ok && pkg.TypesInfo.Uses[ident] == object {
-						mutated = true
-						return false
+						return true
 					}
 				}
-				return true
-			})
-			if mutated {
-				return true
 			}
 		}
 	}

--- a/cli/xgotext/parser/gofile.go
+++ b/cli/xgotext/parser/gofile.go
@@ -424,12 +424,6 @@ func (g *GoFile) resolveStringLiteralState(
 	return nil
 }
 
-// getLiteralFromIdent resolves a declaration without package type information.
-// It is retained for focused AST tests; production extraction uses resolveStringLiteral.
-func getLiteralFromIdent(ident *ast.Ident) *ast.BasicLit {
-	return (&GoFile{}).resolveStringLiteral(ident, token.NoPos, make(map[types.Object]bool))
-}
-
 func literalFromConstantValue(value constant.Value) *ast.BasicLit {
 	if value == nil || value.Kind() != constant.String {
 		return nil

--- a/cli/xgotext/parser/gofile_test.go
+++ b/cli/xgotext/parser/gofile_test.go
@@ -2,8 +2,13 @@ package parser
 
 import (
 	"go/ast"
+	goparser "go/parser"
 	"go/token"
+	"go/types"
+	"slices"
 	"testing"
+
+	"golang.org/x/tools/go/packages"
 )
 
 func TestGetterDef_MaxArgIndex(t *testing.T) {
@@ -143,5 +148,196 @@ func TestGetLiteralFromIdent(t *testing.T) {
 	litY := getLiteralFromIdent(identY)
 	if litY == nil || litY.Value != `"valY"` {
 		t.Errorf("expected valY, got %v", litY)
+	}
+}
+
+type typedASTImporter struct {
+	pkg *types.Package
+}
+
+func (i typedASTImporter) Import(string) (*types.Package, error) {
+	return i.pkg, nil
+}
+
+func addTypedGetter(pkg *types.Package, name string, parameterTypes ...types.Type) {
+	params := make([]*types.Var, len(parameterTypes))
+	for idx, parameterType := range parameterTypes {
+		params[idx] = types.NewVar(token.NoPos, pkg, "", parameterType)
+	}
+
+	signature := types.NewSignatureType(nil, nil, nil, types.NewTuple(params...), types.NewTuple(), false)
+	pkg.Scope().Insert(types.NewFunc(token.NoPos, pkg, name, signature))
+}
+
+func newTypedGoFile(t *testing.T, source string) (*GoFile, *ast.File) {
+	t.Helper()
+
+	fileSet := token.NewFileSet()
+	file, err := goparser.ParseFile(fileSet, "typed.go", source, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotextTypes := types.NewPackage("github.com/leonelquinteros/gotext", "gotext")
+	addTypedGetter(gotextTypes, "Get", types.Typ[types.String])
+	addTypedGetter(gotextTypes, "GetNC",
+		types.Typ[types.String],
+		types.Typ[types.String],
+		types.Typ[types.String],
+		types.Typ[types.String],
+	)
+	gotextTypes.MarkComplete()
+
+	typesInfo := &types.Info{
+		Types: make(map[ast.Expr]types.TypeAndValue),
+		Defs:  make(map[*ast.Ident]types.Object),
+		Uses:  make(map[*ast.Ident]types.Object),
+	}
+	_, typeErr := (&types.Config{
+		Importer: typedASTImporter{pkg: gotextTypes},
+	}).Check("typed", fileSet, []*ast.File{file}, typesInfo)
+	if typeErr != nil {
+		t.Fatalf("type-check typed source: %v", typeErr)
+	}
+
+	g := &GoFile{
+		FilePath: "typed.go",
+		BasePath: ".",
+		Data:     &DomainMap{},
+		FileSet:  fileSet,
+		ImportedPackages: map[string]*packages.Package{
+			"gotext": {
+				PkgPath: "github.com/leonelquinteros/gotext",
+			},
+			"typed": {
+				PkgPath:   "typed",
+				Syntax:    []*ast.File{file},
+				TypesInfo: typesInfo,
+			},
+		},
+	}
+	return g, file
+}
+
+func inspectTypedCalls(g *GoFile, file *ast.File) {
+	ast.Inspect(file, func(node ast.Node) bool {
+		if call, ok := node.(*ast.CallExpr); ok {
+			g.InspectCallExpr(call)
+		}
+		return true
+	})
+}
+
+func makeTypedASTCycle(t *testing.T, file *ast.File) {
+	t.Helper()
+
+	declarations := make(map[string]*ast.ValueSpec, 2)
+	references := make(map[string]*ast.Ident, 2)
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch node := node.(type) {
+		case *ast.ValueSpec:
+			for _, name := range node.Names {
+				if name.Name == "cyclicA" || name.Name == "cyclicB" {
+					declarations[name.Name] = node
+				}
+			}
+		case *ast.Ident:
+			spec, ok := declarations[node.Name]
+			if ok && node.Obj != nil && node.Obj.Decl == spec {
+				if slices.Contains(spec.Names, node) {
+					return true
+				}
+				references[node.Name] = node
+			}
+		}
+		return true
+	})
+
+	for _, name := range []string{"cyclicA", "cyclicB"} {
+		if declarations[name] == nil || references[name] == nil {
+			t.Fatalf("failed to find typed AST cycle node %s", name)
+		}
+	}
+	declarations["cyclicA"].Values = []ast.Expr{references["cyclicB"]}
+	declarations["cyclicB"].Values = []ast.Expr{references["cyclicA"]}
+}
+
+func TestGoFile_InspectCallExpr_TypedASTMutation(t *testing.T) {
+	const source = `package typed
+
+import "github.com/leonelquinteros/gotext"
+
+func example() {
+	unrelated := "unrelated"
+	unrelated = "changed unrelated"
+	_ = unrelated
+	before := "message before mutation"
+	gotext.Get(before)
+
+	mutated := "initial mutation"
+	mutated = "message after mutation"
+	gotext.Get(mutated)
+
+	afterCall := "message before later mutation"
+	gotext.Get(afterCall)
+	afterCall = "message after later mutation"
+}`
+
+	g, file := newTypedGoFile(t, source)
+	inspectTypedCalls(g, file)
+
+	translations := g.Data.Domains["default"].Translations
+	if len(translations) != 2 {
+		t.Fatalf("got %d translations, want 2", len(translations))
+	}
+	if _, ok := translations["message before mutation"]; !ok {
+		t.Error("unmodified identifier before its call was not extracted")
+	}
+	if _, ok := translations["message before later mutation"]; !ok {
+		t.Error("identifier mutated after its call was not extracted")
+	}
+	if _, ok := translations["message after mutation"]; ok {
+		t.Error("identifier mutated before its call was extracted")
+	}
+}
+
+func TestGoFile_InspectCallExpr_TypedASTCycleDoesNotPoisonLaterArgumentsOrCalls(t *testing.T) {
+	const source = `package typed
+
+import "github.com/leonelquinteros/gotext"
+
+var cyclicA string = "initial cyclic A"
+var cyclicB string = "initial cyclic B"
+var contextAfterCycle = "context after cycle"
+var later = "later call"
+
+func example() {
+	gotext.Get(cyclicA)
+	gotext.GetNC("id", "plural", cyclicB, contextAfterCycle)
+	gotext.Get(later)
+}`
+
+	g, file := newTypedGoFile(t, source)
+	makeTypedASTCycle(t, file)
+	inspectTypedCalls(g, file)
+
+	domain := g.Data.Domains["default"]
+	if _, ok := domain.Translations["cyclicA"]; ok {
+		t.Error("cyclic identifier was extracted")
+	}
+	contextTranslations := domain.ContextTranslations[`"context after cycle"`]
+	translation, ok := contextTranslations["id"]
+	if !ok {
+		t.Fatal("later arguments were not extracted after a cyclic identifier")
+	}
+	if translation.Context != `"context after cycle"` {
+		t.Errorf("context = %q, want %q", translation.Context, `"context after cycle"`)
+	}
+	if _, ok := domain.Translations["later call"]; !ok {
+		t.Error("later call was not extracted after a cyclic identifier")
+	}
+	if len(domain.Translations) != 1 || len(contextTranslations) != 1 {
+		t.Fatalf("got %d uncontexted and %d contextual translations, want 1 each",
+			len(domain.Translations), len(contextTranslations))
 	}
 }

--- a/cli/xgotext/parser/gofile_test.go
+++ b/cli/xgotext/parser/gofile_test.go
@@ -6,6 +6,7 @@ import (
 	"go/token"
 	"go/types"
 	"slices"
+	"strconv"
 	"testing"
 
 	"golang.org/x/tools/go/packages"
@@ -159,33 +160,147 @@ func (i typedASTImporter) Import(string) (*types.Package, error) {
 	return i.pkg, nil
 }
 
-func addTypedGetter(pkg *types.Package, name string, parameterTypes ...types.Type) {
+func typedSignature(
+	pkg *types.Package,
+	receiver types.Type,
+	variadic bool,
+	parameterTypes ...types.Type,
+) *types.Signature {
 	params := make([]*types.Var, len(parameterTypes))
 	for idx, parameterType := range parameterTypes {
+		if variadic && idx == len(parameterTypes)-1 {
+			parameterType = types.NewSlice(parameterType)
+		}
 		params[idx] = types.NewVar(token.NoPos, pkg, "", parameterType)
 	}
 
-	signature := types.NewSignatureType(nil, nil, nil, types.NewTuple(params...), types.NewTuple(), false)
-	pkg.Scope().Insert(types.NewFunc(token.NoPos, pkg, name, signature))
+	var receiverVar *types.Var
+	if receiver != nil {
+		receiverVar = types.NewVar(token.NoPos, pkg, "", receiver)
+	}
+	return types.NewSignatureType(
+		receiverVar,
+		nil,
+		nil,
+		types.NewTuple(params...),
+		types.NewTuple(),
+		variadic,
+	)
 }
 
-func newTypedGoFile(t *testing.T, source string) (*GoFile, *ast.File) {
-	t.Helper()
+func addTypedGetterWithVariadic(pkg *types.Package, name string, variadic bool, parameterTypes ...types.Type) {
+	pkg.Scope().Insert(types.NewFunc(token.NoPos, pkg, name, typedSignature(pkg, nil, variadic, parameterTypes...)))
+}
 
+func addTypedMethodWithVariadic(
+	pkg *types.Package,
+	receiver *types.Named,
+	name string,
+	variadic bool,
+	parameterTypes ...types.Type,
+) {
+	receiver.AddMethod(types.NewFunc(
+		token.NoPos,
+		pkg,
+		name,
+		typedSignature(pkg, receiver, variadic, parameterTypes...),
+	))
+}
+
+func addTypedReceiver(pkg *types.Package, name string, anyType types.Type) *types.Named {
+	object := types.NewTypeName(token.NoPos, pkg, name, nil)
+	receiver := types.NewNamed(object, types.NewStruct(nil, nil), nil)
+	pkg.Scope().Insert(object)
+	for getterName, def := range gotextGetter {
+		parameterTypes := make([]types.Type, def.MaxArgIndex()+2)
+		for idx := range parameterTypes {
+			parameterTypes[idx] = anyType
+		}
+		addTypedMethodWithVariadic(pkg, receiver, getterName, true, parameterTypes...)
+	}
+	return receiver
+}
+func addTypedInterface(pkg *types.Package, name string, anyType types.Type) *types.Named {
+	methods := make([]*types.Func, 0, len(gotextGetter))
+	for getterName, def := range gotextGetter {
+		parameterTypes := make([]types.Type, def.MaxArgIndex()+2)
+		for idx := range parameterTypes {
+			parameterTypes[idx] = anyType
+		}
+		methods = append(methods, types.NewFunc(
+			token.NoPos,
+			pkg,
+			getterName,
+			typedSignature(pkg, nil, true, parameterTypes...),
+		))
+	}
+	interfaceType := types.NewInterfaceType(methods, nil)
+	interfaceType.Complete()
+	object := types.NewTypeName(token.NoPos, pkg, name, nil)
+	named := types.NewNamed(object, interfaceType, nil)
+	pkg.Scope().Insert(object)
+	return named
+}
+
+func buildTypedGoFile(source string) (*GoFile, *ast.File, error) {
 	fileSet := token.NewFileSet()
 	file, err := goparser.ParseFile(fileSet, "typed.go", source, 0)
 	if err != nil {
-		t.Fatal(err)
+		return nil, nil, err
 	}
 
 	gotextTypes := types.NewPackage("github.com/leonelquinteros/gotext", "gotext")
-	addTypedGetter(gotextTypes, "Get", types.Typ[types.String])
-	addTypedGetter(gotextTypes, "GetNC",
+	anyType := types.NewInterfaceType(nil, nil)
+	anyType.Complete()
+	addTypedGetterWithVariadic(gotextTypes, "Get", true, types.Typ[types.String], anyType)
+	addTypedGetterWithVariadic(gotextTypes, "GetN", true,
 		types.Typ[types.String],
 		types.Typ[types.String],
-		types.Typ[types.String],
-		types.Typ[types.String],
+		anyType,
+		anyType,
 	)
+	addTypedGetterWithVariadic(gotextTypes, "GetD", true,
+		types.Typ[types.String],
+		types.Typ[types.String],
+		anyType,
+	)
+	addTypedGetterWithVariadic(gotextTypes, "GetND", true,
+		types.Typ[types.String],
+		types.Typ[types.String],
+		types.Typ[types.String],
+		anyType,
+		anyType,
+	)
+	addTypedGetterWithVariadic(gotextTypes, "GetC", true,
+		types.Typ[types.String],
+		types.Typ[types.String],
+		anyType,
+	)
+	addTypedGetterWithVariadic(gotextTypes, "GetNC", true,
+		types.Typ[types.String],
+		types.Typ[types.String],
+		anyType,
+		types.Typ[types.String],
+		anyType,
+	)
+	addTypedGetterWithVariadic(gotextTypes, "GetDC", true,
+		types.Typ[types.String],
+		types.Typ[types.String],
+		types.Typ[types.String],
+		anyType,
+	)
+	addTypedGetterWithVariadic(gotextTypes, "GetNDC", true,
+		types.Typ[types.String],
+		types.Typ[types.String],
+		types.Typ[types.String],
+		anyType,
+		types.Typ[types.String],
+		anyType,
+	)
+	addTypedReceiver(gotextTypes, "Locale", anyType)
+	addTypedReceiver(gotextTypes, "Po", anyType)
+	addTypedReceiver(gotextTypes, "Domain", anyType)
+	addTypedInterface(gotextTypes, "Translator", anyType)
 	gotextTypes.MarkComplete()
 
 	typesInfo := &types.Info{
@@ -197,24 +312,39 @@ func newTypedGoFile(t *testing.T, source string) (*GoFile, *ast.File) {
 		Importer: typedASTImporter{pkg: gotextTypes},
 	}).Check("typed", fileSet, []*ast.File{file}, typesInfo)
 	if typeErr != nil {
-		t.Fatalf("type-check typed source: %v", typeErr)
+		return nil, nil, typeErr
+	}
+	importedPackages := map[string]*packages.Package{
+		"gotext": {
+			PkgPath: "github.com/leonelquinteros/gotext",
+		},
+		"typed": {
+			PkgPath:   "typed",
+			Syntax:    []*ast.File{file},
+			TypesInfo: typesInfo,
+		},
+	}
+	for _, importSpec := range file.Imports {
+		if importSpec.Name != nil {
+			importedPackages[importSpec.Name.Name] = importedPackages["gotext"]
+		}
 	}
 
 	g := &GoFile{
-		FilePath: "typed.go",
-		BasePath: ".",
-		Data:     &DomainMap{},
-		FileSet:  fileSet,
-		ImportedPackages: map[string]*packages.Package{
-			"gotext": {
-				PkgPath: "github.com/leonelquinteros/gotext",
-			},
-			"typed": {
-				PkgPath:   "typed",
-				Syntax:    []*ast.File{file},
-				TypesInfo: typesInfo,
-			},
-		},
+		FilePath:         "typed.go",
+		BasePath:         ".",
+		Data:             &DomainMap{},
+		FileSet:          fileSet,
+		ImportedPackages: importedPackages,
+	}
+	return g, file, nil
+}
+
+func newTypedGoFile(t *testing.T, source string) (*GoFile, *ast.File) {
+	t.Helper()
+	g, file, err := buildTypedGoFile(source)
+	if err != nil {
+		t.Fatal(err)
 	}
 	return g, file
 }
@@ -225,6 +355,250 @@ func inspectTypedCalls(g *GoFile, file *ast.File) {
 			g.InspectCallExpr(call)
 		}
 		return true
+	})
+}
+func TestGoFile_InspectCallExpr_GetterMappings(t *testing.T) {
+	const source = `package typed
+
+import gt "github.com/leonelquinteros/gotext"
+
+func example() {
+	gt.Get("get-id", "format %s")
+	gt.GetN("getn-id", "getn-plural", 2, "format %s")
+	gt.GetD("getd-domain", "getd-id", "format %s")
+	gt.GetND("getnd-domain", "getnd-id", "getnd-plural", 2, "format %s")
+	gt.GetC("getc-id", "getc-context", "format %s")
+	gt.GetNC("getnc-id", "getnc-plural", 2, "getnc-context", "format %s")
+	gt.GetDC("getdc-domain", "getdc-id", "getdc-context", "format %s")
+	gt.GetNDC("getndc-domain", "getndc-id", "getndc-plural", 2, "getndc-context", "format %s")
+}`
+
+	g, file := newTypedGoFile(t, source)
+	inspectTypedCalls(g, file)
+
+	type want struct {
+		domain  string
+		id      string
+		plural  string
+		context string
+	}
+	expected := []want{
+		{id: "get-id"},
+		{id: "getn-id", plural: "getn-plural"},
+		{domain: "getd-domain", id: "getd-id"},
+		{domain: "getnd-domain", id: "getnd-id", plural: "getnd-plural"},
+		{id: "getc-id", context: `"getc-context"`},
+		{id: "getnc-id", plural: "getnc-plural", context: `"getnc-context"`},
+		{domain: "getdc-domain", id: "getdc-id", context: `"getdc-context"`},
+		{domain: "getndc-domain", id: "getndc-id", plural: "getndc-plural", context: `"getndc-context"`},
+	}
+
+	if len(g.Data.Domains) != 5 {
+		t.Fatalf("got %d domains, want 5", len(g.Data.Domains))
+	}
+	for _, expected := range expected {
+		domain := g.Data.Domains[expected.domain]
+		if domain == nil {
+			domain = g.Data.Domains["default"]
+		}
+		if expected.context == "" {
+			translation := domain.Translations[expected.id]
+			if translation == nil {
+				t.Fatalf("missing translation %q in domain %q", expected.id, expected.domain)
+			}
+			if translation.MsgIDPlural != expected.plural || translation.Context != "" {
+				t.Errorf("translation %q = plural %q/context %q, want plural %q/context empty",
+					expected.id, translation.MsgIDPlural, translation.Context, expected.plural)
+			}
+			continue
+		}
+		translation := domain.ContextTranslations[expected.context][expected.id]
+		if translation == nil {
+			t.Fatalf("missing contextual translation %q/%q", expected.context, expected.id)
+		}
+		if translation.MsgIDPlural != expected.plural || translation.Context != expected.context {
+			t.Errorf("translation %q = plural %q/context %q, want plural %q/context %q",
+				expected.id, translation.MsgIDPlural, translation.Context, expected.plural, expected.context)
+		}
+	}
+}
+
+func TestGoFile_InspectCallExpr_DotImportsReceiversAndShadowedMethods(t *testing.T) {
+	const source = `package typed
+
+import . "github.com/leonelquinteros/gotext"
+
+type local struct{}
+
+func (local) Get(id string, vars ...any) string {
+	return id
+}
+
+func example() {
+	var locale Locale
+	var pointer *Locale
+	var translator Translator
+	Get("dot-id")
+	locale.Get("named-id")
+	pointer.Get("pointer-id")
+	translator.Get("interface-id")
+	var localValue local
+	localValue.Get("local-id")
+}`
+
+	g, file := newTypedGoFile(t, source)
+	inspectTypedCalls(g, file)
+
+	domain := g.Data.Domains["default"]
+	if domain == nil {
+		t.Fatal("dot import and receiver calls did not create default domain")
+	}
+	for _, id := range []string{"dot-id", "named-id", "pointer-id", "interface-id"} {
+		if domain.Translations[id] == nil {
+			t.Errorf("missing supported translation %q", id)
+		}
+	}
+	if _, ok := domain.Translations["local-id"]; ok {
+		t.Error("same-named local method was extracted")
+	}
+	if len(domain.Translations) != 4 {
+		t.Fatalf("got %d translations, want 4", len(domain.Translations))
+	}
+}
+
+func TestGoFile_InspectCallExpr_ConstantFormsAndRangeMutation(t *testing.T) {
+	const source = `package typed
+
+import gt "github.com/leonelquinteros/gotext"
+
+const (
+	firstConst = "first"
+	inheritedConst
+	aliasConst = firstConst + "-alias"
+	concatenatedConst = "left" + "right"
+	convertedConst = string('x')
+)
+
+func dynamicString() string {
+	return "dynamic"
+}
+
+func example() {
+	gt.Get(firstConst)
+	gt.Get(inheritedConst)
+	gt.Get(aliasConst)
+	gt.Get(concatenatedConst)
+	gt.Get(convertedConst)
+
+	staticVariable := "static"
+	gt.Get(staticVariable)
+	afterCall := "before"
+	gt.Get(afterCall)
+	afterCall = "after"
+
+	dynamicVariable := dynamicString()
+	gt.Get(dynamicVariable)
+	mutatedVariable := "before mutation"
+	mutatedVariable = "after mutation"
+	gt.Get(mutatedVariable)
+
+	rangedVariable := "initial"
+	for _, rangedVariable = range []string{"range"} {
+		gt.Get(rangedVariable)
+	}
+}`
+
+	g, file := newTypedGoFile(t, source)
+	inspectTypedCalls(g, file)
+
+	domain := g.Data.Domains["default"]
+	if domain == nil {
+		t.Fatal("constant calls did not create default domain")
+	}
+	for _, id := range []string{
+		"first",
+		"first-alias",
+		"leftright",
+		"x",
+		"static",
+		"before",
+	} {
+		if domain.Translations[id] == nil {
+			t.Errorf("missing static translation %q", id)
+		}
+	}
+	for _, id := range []string{"dynamic", "before mutation", "after mutation", "range"} {
+		if _, ok := domain.Translations[id]; ok {
+			t.Errorf("dynamic or mutated translation %q was extracted", id)
+		}
+	}
+}
+
+func FuzzGoFileInspectCallExprConstantForms(f *testing.F) {
+	for _, seed := range []string{
+		`"seed"`,
+		"`raw seed`",
+		`"left" + "right"`,
+		`string('x')`,
+		`not valid`,
+		`"unterminated`,
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, expression string) {
+		if len(expression) > 64<<10 {
+			return
+		}
+		source := `package typed
+
+import gt "github.com/leonelquinteros/gotext"
+
+func example() {
+	gt.Get(` + expression + `)
+}`
+		g, file, err := buildTypedGoFile(source)
+		if err != nil {
+			return
+		}
+
+		var calls []*ast.CallExpr
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if ok && selector.Sel != nil && selector.Sel.Name == "Get" {
+				calls = append(calls, call)
+			}
+			return true
+		})
+		if len(calls) != 1 || len(calls[0].Args) == 0 {
+			return
+		}
+
+		call := calls[0]
+		g.InspectCallExpr(call)
+		literal := g.resolveStringLiteral(call.Args[0], call.Pos(), nil)
+		if literal == nil {
+			if len(g.Data.Domains) != 0 {
+				t.Fatal("dynamic expression produced a translation")
+			}
+			return
+		}
+		value, err := strconv.Unquote(literal.Value)
+		if err != nil {
+			t.Fatalf("resolved literal %q is not a string: %v", literal.Value, err)
+		}
+		domain := g.Data.Domains["default"]
+		if domain == nil {
+			t.Fatal("resolved literal did not initialize the default domain")
+		}
+		translation := domain.Translations[value]
+		if translation == nil {
+			t.Fatalf("resolved literal %q was not extracted", value)
+		}
 	})
 }
 
@@ -339,5 +713,161 @@ func example() {
 	if len(domain.Translations) != 1 || len(contextTranslations) != 1 {
 		t.Fatalf("got %d uncontexted and %d contextual translations, want 1 each",
 			len(domain.Translations), len(contextTranslations))
+	}
+}
+
+func TestGoFile_ResolveStringLiteral_UsesOwningPackageSyntax(t *testing.T) {
+	const source = `package typed
+
+import "github.com/leonelquinteros/gotext"
+
+var crossFile = "cross-file"
+
+func example() {
+	gotext.Get(crossFile)
+}`
+
+	g, file := newTypedGoFile(t, source)
+	var call *ast.CallExpr
+	var getter *ast.Ident
+	var declaration *ast.GenDecl
+	for _, decl := range file.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.VAR {
+			continue
+		}
+		declaration = genDecl
+		break
+	}
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch node := node.(type) {
+		case *ast.CallExpr:
+			call = node
+		case *ast.SelectorExpr:
+			if node.Sel != nil && node.Sel.Name == "Get" {
+				getter = node.Sel
+			}
+		}
+		return true
+	})
+	if call == nil || getter == nil || declaration == nil {
+		t.Fatal("failed to find getter call and package-level declaration")
+	}
+
+	gotextObject := g.GetType(getter)
+	if gotextObject == nil || gotextObject.Pkg() == nil {
+		t.Fatal("getter has no owning package")
+	}
+	declIndex := slices.Index(file.Decls, ast.Decl(declaration))
+	file.Decls = append(file.Decls[:declIndex], file.Decls[declIndex+1:]...)
+	declarationFile, err := goparser.ParseFile(g.FileSet, "declaration.go", `package typed
+
+var crossFile = "cross-file"
+`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	typesInfo := &types.Info{
+		Types: make(map[ast.Expr]types.TypeAndValue),
+		Defs:  make(map[*ast.Ident]types.Object),
+		Uses:  make(map[*ast.Ident]types.Object),
+	}
+	if _, err := (&types.Config{
+		Importer: typedASTImporter{pkg: gotextObject.Pkg()},
+	}).Check("typed", g.FileSet, []*ast.File{file, declarationFile}, typesInfo); err != nil {
+		t.Fatal(err)
+	}
+	ownerPackage := g.ImportedPackages["typed"]
+	if ownerPackage == nil {
+		t.Fatal("typed package metadata is missing")
+	}
+	ownerPackage.Syntax = []*ast.File{file, declarationFile}
+	ownerPackage.TypesInfo = typesInfo
+
+	var use, definition *ast.Ident
+	if len(call.Args) > 0 {
+		use, _ = call.Args[0].(*ast.Ident)
+	}
+	ast.Inspect(declarationFile, func(node ast.Node) bool {
+		ident, ok := node.(*ast.Ident)
+		if ok && ident.Name == "crossFile" {
+			definition = ident
+			return false
+		}
+		return true
+	})
+	if use == nil || definition == nil {
+		t.Fatal("failed to find type-checked getter argument and declaration")
+	}
+	object := g.GetType(definition)
+	if object == nil || object.Pkg() == nil {
+		t.Fatal("cross-file identifier has no owning package object")
+	}
+
+	unrelatedFile, err := goparser.ParseFile(token.NewFileSet(), "unrelated.go", `package unrelated
+
+var crossFile = "unrelated declaration"
+
+func mutate() {
+	crossFile = "unrelated mutation"
+}
+`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var unrelatedDeclaration, unrelatedMutation *ast.Ident
+	ast.Inspect(unrelatedFile, func(node ast.Node) bool {
+		switch node := node.(type) {
+		case *ast.ValueSpec:
+			if len(node.Names) > 0 {
+				unrelatedDeclaration = node.Names[0]
+			}
+		case *ast.AssignStmt:
+			if len(node.Lhs) > 0 {
+				unrelatedMutation, _ = node.Lhs[0].(*ast.Ident)
+				if unrelatedMutation != nil {
+					unrelatedMutation.NamePos = token.Pos(1)
+				}
+			}
+		}
+		return true
+	})
+	if unrelatedDeclaration == nil || unrelatedMutation == nil {
+		t.Fatal("failed to find unrelated declarations")
+	}
+	unrelatedPackage := &packages.Package{
+		PkgPath: "example.com/unrelated",
+		Syntax:  []*ast.File{unrelatedFile},
+		TypesInfo: &types.Info{
+			Defs: map[*ast.Ident]types.Object{
+				unrelatedDeclaration: object,
+			},
+			Uses: map[*ast.Ident]types.Object{
+				unrelatedMutation: object,
+			},
+		},
+	}
+
+	savedPackages := g.ImportedPackages
+	g.ImportedPackages = map[string]*packages.Package{"unrelated": unrelatedPackage}
+	if _, _, ok := g.declarationForObject(object); ok {
+		t.Fatal("unrelated package declaration was scanned")
+	}
+	g.ImportedPackages = savedPackages
+	g.ImportedPackages["unrelated"] = unrelatedPackage
+
+	if g.isMutatedBefore(object, call.Pos()) {
+		t.Fatal("unrelated package mutation was scanned")
+	}
+	literal := g.resolveStringLiteral(use, call.Pos(), nil)
+	if literal == nil || literal.Value != `"cross-file"` {
+		t.Fatalf("resolved literal = %v, want %q", literal, `"cross-file"`)
+	}
+
+	g.InspectCallExpr(call)
+	domain := g.Data.Domains["default"]
+	if domain == nil || domain.Translations["cross-file"] == nil {
+		t.Fatal("cross-file declaration was not extracted")
 	}
 }

--- a/cli/xgotext/parser/gofile_test.go
+++ b/cli/xgotext/parser/gofile_test.go
@@ -1,163 +1,61 @@
 package parser
 
 import (
+	"fmt"
 	"go/ast"
+	"go/constant"
 	goparser "go/parser"
 	"go/token"
 	"go/types"
-	"slices"
-	"strconv"
 	"testing"
 
 	"golang.org/x/tools/go/packages"
 )
 
-func TestGetterDef_MaxArgIndex(t *testing.T) {
-	tests := []struct {
-		def  GetterDef
-		want int
-	}{
-		{GetterDef{0, -1, -1, -1}, 0},
-		{GetterDef{0, 1, -1, -1}, 1},
-		{GetterDef{1, -1, -1, 0}, 1},
-		{GetterDef{1, 2, 4, 0}, 4},
-	}
-	for _, tt := range tests {
-		if got := tt.def.MaxArgIndex(); got != tt.want {
-			t.Errorf("GetterDef.MaxArgIndex() = %v, want %v", got, tt.want)
-		}
-	}
-}
-
-func TestGoFile_ParseGetter(t *testing.T) {
-	data := &DomainMap{}
-	g := &GoFile{
-		Data: data,
-	}
-
-	def := gotextGetter["Get"]
-	args := []*ast.BasicLit{
-		{Kind: token.STRING, Value: "\"msgid\""},
-	}
-	g.ParseGetter(def, args, "file.go:10")
-
-	if len(data.Domains["default"].Translations) != 1 {
-		t.Error("ParseGetter failed for simple Get")
-	}
-
-	// Test plural
-	defN := gotextGetter["GetN"]
-	argsN := []*ast.BasicLit{
-		{Kind: token.STRING, Value: "\"singular\""},
-		{Kind: token.STRING, Value: "\"plural\""},
-	}
-	g.ParseGetter(defN, argsN, "file.go:20")
-	if data.Domains["default"].Translations["singular"].MsgIDPlural != "plural" {
-		t.Error("ParseGetter failed for GetN")
-	}
-
-	// Test Domain
-	defD := gotextGetter["GetD"]
-	argsD := []*ast.BasicLit{
-		{Kind: token.STRING, Value: "\"domain1\""},
-		{Kind: token.STRING, Value: "\"msgid_d\""},
-	}
-	g.ParseGetter(defD, argsD, "file.go:30")
-	if _, ok := data.Domains["domain1"]; !ok {
-		t.Error("ParseGetter failed for GetD domain creation")
-	}
-}
-
-func TestGoFile_ParseGetter_Errors(t *testing.T) {
-	data := &DomainMap{}
-	g := &GoFile{
-		Data: data,
-	}
-
-	// Not enough args for GetN (needs 2: ID and Plural, which are index 0 and 1. MaxArgIndex is 1)
-	defN := gotextGetter["GetN"]
-	args := []*ast.BasicLit{
-		{Kind: token.STRING, Value: "\"singular\""},
-	} // only 1 arg, index 0. len(args) == 1. 1 <= 1 is true. Should return.
-	g.ParseGetter(defN, args, "file.go:10")
-	if len(data.Domains) != 0 {
-		t.Error("ParseGetter should have failed for not enough args (len 1 for GetN)")
-	}
-
-	// Not enough args for GetD (needs 2: Domain and ID, index 0 and 1. MaxArgIndex is 1)
-	defD := gotextGetter["GetD"]
-	argsD := []*ast.BasicLit{
-		{Kind: token.STRING, Value: "\"domain1\""},
-	}
-	g.ParseGetter(defD, argsD, "file.go:15")
-	if len(data.Domains) != 0 {
-		t.Error("ParseGetter should have failed for not enough args (len 1 for GetD)")
-	}
-
-	// ID not a string
-	defGet := gotextGetter["Get"]
-	args2 := []*ast.BasicLit{
-		{Kind: token.INT, Value: "123"},
-	}
-	g.ParseGetter(defGet, args2, "file.go:20")
-
-	// Missing or unsupported arguments must not cause an index-out-of-range panic.
-	g.ParseGetter(defGet, nil, "file.go:30")
-	g.ParseGetter(gotextGetter["GetD"], []*ast.BasicLit{nil}, "file.go:40")
-}
-
-func TestGetLiteralFromIdent(t *testing.T) {
-	// ValueSpec multi-var: const (A = "valA"; B = "valB")
-	valA := &ast.BasicLit{Kind: token.STRING, Value: `"valA"`}
-	valB := &ast.BasicLit{Kind: token.STRING, Value: `"valB"`}
-	identA := &ast.Ident{Name: "A"}
-	identB := &ast.Ident{Name: "B"}
-	spec := &ast.ValueSpec{
-		Names:  []*ast.Ident{identA, identB},
-		Values: []ast.Expr{valA, valB},
-	}
-	identA.Obj = &ast.Object{Decl: spec} //nolint:staticcheck
-	identB.Obj = &ast.Object{Decl: spec} //nolint:staticcheck
-
-	litA := getLiteralFromIdent(identA)
-	if litA == nil || litA.Value != `"valA"` {
-		t.Errorf("expected valA, got %v", litA)
-	}
-
-	litB := getLiteralFromIdent(identB)
-	if litB == nil || litB.Value != `"valB"` {
-		t.Errorf("expected valB, got %v", litB)
-	}
-
-	// AssignStmt multi-var: x, y := "valX", "valY"
-	valX := &ast.BasicLit{Kind: token.STRING, Value: `"valX"`}
-	valY := &ast.BasicLit{Kind: token.STRING, Value: `"valY"`}
-	identX := &ast.Ident{Name: "x"}
-	identY := &ast.Ident{Name: "y"}
-	assign := &ast.AssignStmt{
-		Lhs: []ast.Expr{identX, identY},
-		Rhs: []ast.Expr{valX, valY},
-	}
-	identX.Obj = &ast.Object{Decl: assign} //nolint:staticcheck
-	identY.Obj = &ast.Object{Decl: assign} //nolint:staticcheck
-
-	litX := getLiteralFromIdent(identX)
-	if litX == nil || litX.Value != `"valX"` {
-		t.Errorf("expected valX, got %v", litX)
-	}
-
-	litY := getLiteralFromIdent(identY)
-	if litY == nil || litY.Value != `"valY"` {
-		t.Errorf("expected valY, got %v", litY)
-	}
-}
+const typedGotextPackagePath = "github.com/leonelquinteros/gotext"
 
 type typedASTImporter struct {
-	pkg *types.Package
+	packages map[string]*types.Package
 }
 
-func (i typedASTImporter) Import(string) (*types.Package, error) {
-	return i.pkg, nil
+func (i typedASTImporter) Import(path string) (*types.Package, error) {
+	pkg := i.packages[path]
+	if pkg == nil {
+		return nil, fmt.Errorf("typed fixture importer has no package %q", path)
+	}
+	return pkg, nil
+}
+
+type typedGetterSpec struct {
+	name           string
+	parameterTypes []types.Type
+}
+
+func typedGetterSpecs(anyType types.Type) []typedGetterSpec {
+	stringType := types.Typ[types.String]
+	intType := types.Typ[types.Int]
+	return []typedGetterSpec{
+		{name: "Get", parameterTypes: []types.Type{stringType, anyType}},
+		{name: "GetN", parameterTypes: []types.Type{stringType, stringType, intType, anyType}},
+		{name: "GetD", parameterTypes: []types.Type{stringType, stringType, anyType}},
+		{name: "GetND", parameterTypes: []types.Type{stringType, stringType, stringType, intType, anyType}},
+		{name: "GetC", parameterTypes: []types.Type{stringType, stringType, anyType}},
+		{name: "GetNC", parameterTypes: []types.Type{stringType, stringType, intType, stringType, anyType}},
+		{name: "GetDC", parameterTypes: []types.Type{stringType, stringType, stringType, anyType}},
+		{name: "GetNDC", parameterTypes: []types.Type{stringType, stringType, stringType, intType, stringType, anyType}},
+	}
+}
+
+func typedReceiverGetterSpecs(anyType types.Type, name string) []typedGetterSpec {
+	specs := typedGetterSpecs(anyType)
+	switch name {
+	case "Locale", "Po":
+		return specs
+	case "Domain", "Translator":
+		return []typedGetterSpec{specs[0], specs[1], specs[4], specs[5]}
+	default:
+		panic("unknown typed receiver " + name)
+	}
 }
 
 func typedSignature(
@@ -188,50 +86,38 @@ func typedSignature(
 	)
 }
 
-func addTypedGetterWithVariadic(pkg *types.Package, name string, variadic bool, parameterTypes ...types.Type) {
-	pkg.Scope().Insert(types.NewFunc(token.NoPos, pkg, name, typedSignature(pkg, nil, variadic, parameterTypes...)))
-}
-
-func addTypedMethodWithVariadic(
-	pkg *types.Package,
-	receiver *types.Named,
-	name string,
-	variadic bool,
-	parameterTypes ...types.Type,
-) {
-	receiver.AddMethod(types.NewFunc(
+func addTypedGetterWithVariadic(pkg *types.Package, spec typedGetterSpec) {
+	pkg.Scope().Insert(types.NewFunc(
 		token.NoPos,
 		pkg,
-		name,
-		typedSignature(pkg, receiver, variadic, parameterTypes...),
+		spec.name,
+		typedSignature(pkg, nil, true, spec.parameterTypes...),
 	))
 }
 
-func addTypedReceiver(pkg *types.Package, name string, anyType types.Type) *types.Named {
+func addTypedReceiver(pkg *types.Package, name string, specs []typedGetterSpec) *types.Named {
 	object := types.NewTypeName(token.NoPos, pkg, name, nil)
 	receiver := types.NewNamed(object, types.NewStruct(nil, nil), nil)
 	pkg.Scope().Insert(object)
-	for getterName, def := range gotextGetter {
-		parameterTypes := make([]types.Type, def.MaxArgIndex()+2)
-		for idx := range parameterTypes {
-			parameterTypes[idx] = anyType
-		}
-		addTypedMethodWithVariadic(pkg, receiver, getterName, true, parameterTypes...)
+	for _, spec := range specs {
+		receiver.AddMethod(types.NewFunc(
+			token.NoPos,
+			pkg,
+			spec.name,
+			typedSignature(pkg, receiver, true, spec.parameterTypes...),
+		))
 	}
 	return receiver
 }
-func addTypedInterface(pkg *types.Package, name string, anyType types.Type) *types.Named {
-	methods := make([]*types.Func, 0, len(gotextGetter))
-	for getterName, def := range gotextGetter {
-		parameterTypes := make([]types.Type, def.MaxArgIndex()+2)
-		for idx := range parameterTypes {
-			parameterTypes[idx] = anyType
-		}
+
+func addTypedInterface(pkg *types.Package, name string, specs []typedGetterSpec) *types.Named {
+	methods := make([]*types.Func, 0, len(specs))
+	for _, spec := range specs {
 		methods = append(methods, types.NewFunc(
 			token.NoPos,
 			pkg,
-			getterName,
-			typedSignature(pkg, nil, true, parameterTypes...),
+			spec.name,
+			typedSignature(pkg, nil, true, spec.parameterTypes...),
 		))
 	}
 	interfaceType := types.NewInterfaceType(methods, nil)
@@ -242,6 +128,15 @@ func addTypedInterface(pkg *types.Package, name string, anyType types.Type) *typ
 	return named
 }
 
+func typedTypesInfo() *types.Info {
+	return &types.Info{
+		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Defs:       make(map[*ast.Ident]types.Object),
+		Uses:       make(map[*ast.Ident]types.Object),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+	}
+}
+
 func buildTypedGoFile(source string) (*GoFile, *ast.File, error) {
 	fileSet := token.NewFileSet()
 	file, err := goparser.ParseFile(fileSet, "typed.go", source, 0)
@@ -249,84 +144,48 @@ func buildTypedGoFile(source string) (*GoFile, *ast.File, error) {
 		return nil, nil, err
 	}
 
-	gotextTypes := types.NewPackage("github.com/leonelquinteros/gotext", "gotext")
+	gotextTypes := types.NewPackage(typedGotextPackagePath, "gotext")
 	anyType := types.NewInterfaceType(nil, nil)
 	anyType.Complete()
-	addTypedGetterWithVariadic(gotextTypes, "Get", true, types.Typ[types.String], anyType)
-	addTypedGetterWithVariadic(gotextTypes, "GetN", true,
-		types.Typ[types.String],
-		types.Typ[types.String],
-		anyType,
-		anyType,
-	)
-	addTypedGetterWithVariadic(gotextTypes, "GetD", true,
-		types.Typ[types.String],
-		types.Typ[types.String],
-		anyType,
-	)
-	addTypedGetterWithVariadic(gotextTypes, "GetND", true,
-		types.Typ[types.String],
-		types.Typ[types.String],
-		types.Typ[types.String],
-		anyType,
-		anyType,
-	)
-	addTypedGetterWithVariadic(gotextTypes, "GetC", true,
-		types.Typ[types.String],
-		types.Typ[types.String],
-		anyType,
-	)
-	addTypedGetterWithVariadic(gotextTypes, "GetNC", true,
-		types.Typ[types.String],
-		types.Typ[types.String],
-		anyType,
-		types.Typ[types.String],
-		anyType,
-	)
-	addTypedGetterWithVariadic(gotextTypes, "GetDC", true,
-		types.Typ[types.String],
-		types.Typ[types.String],
-		types.Typ[types.String],
-		anyType,
-	)
-	addTypedGetterWithVariadic(gotextTypes, "GetNDC", true,
-		types.Typ[types.String],
-		types.Typ[types.String],
-		types.Typ[types.String],
-		anyType,
-		types.Typ[types.String],
-		anyType,
-	)
-	addTypedReceiver(gotextTypes, "Locale", anyType)
-	addTypedReceiver(gotextTypes, "Po", anyType)
-	addTypedReceiver(gotextTypes, "Domain", anyType)
-	addTypedInterface(gotextTypes, "Translator", anyType)
+	specs := typedGetterSpecs(anyType)
+	for _, spec := range specs {
+		addTypedGetterWithVariadic(gotextTypes, spec)
+	}
+	addTypedReceiver(gotextTypes, "Locale", typedReceiverGetterSpecs(anyType, "Locale"))
+	addTypedReceiver(gotextTypes, "Po", typedReceiverGetterSpecs(anyType, "Po"))
+	addTypedReceiver(gotextTypes, "Domain", typedReceiverGetterSpecs(anyType, "Domain"))
+	addTypedInterface(gotextTypes, "Translator", typedReceiverGetterSpecs(anyType, "Translator"))
 	gotextTypes.MarkComplete()
 
-	typesInfo := &types.Info{
-		Types: make(map[ast.Expr]types.TypeAndValue),
-		Defs:  make(map[*ast.Ident]types.Object),
-		Uses:  make(map[*ast.Ident]types.Object),
-	}
-	_, typeErr := (&types.Config{
-		Importer: typedASTImporter{pkg: gotextTypes},
+	typesInfo := typedTypesInfo()
+	ownerTypes, typeErr := (&types.Config{
+		Importer: typedASTImporter{packages: map[string]*types.Package{
+			typedGotextPackagePath: gotextTypes,
+		}},
 	}).Check("typed", fileSet, []*ast.File{file}, typesInfo)
 	if typeErr != nil {
 		return nil, nil, typeErr
 	}
+
+	gotextPackage := &packages.Package{
+		Name:    "gotext",
+		PkgPath: typedGotextPackagePath,
+		Types:   gotextTypes,
+	}
+	ownerPackage := &packages.Package{
+		Name:      "typed",
+		PkgPath:   "typed",
+		Syntax:    []*ast.File{file},
+		Types:     ownerTypes,
+		TypesInfo: typesInfo,
+	}
 	importedPackages := map[string]*packages.Package{
-		"gotext": {
-			PkgPath: "github.com/leonelquinteros/gotext",
-		},
-		"typed": {
-			PkgPath:   "typed",
-			Syntax:    []*ast.File{file},
-			TypesInfo: typesInfo,
-		},
+		"gotext": gotextPackage,
+		"typed":  ownerPackage,
 	}
 	for _, importSpec := range file.Imports {
 		if importSpec.Name != nil {
-			importedPackages[importSpec.Name.Name] = importedPackages["gotext"]
+			importedPackages[importSpec.Name.Name] = gotextPackage
 		}
 	}
 
@@ -376,49 +235,44 @@ func example() {
 	g, file := newTypedGoFile(t, source)
 	inspectTypedCalls(g, file)
 
-	type want struct {
-		domain  string
-		id      string
-		plural  string
-		context string
+	type expectedTranslation struct {
+		domain, id, plural, context, location string
 	}
-	expected := []want{
-		{id: "get-id"},
-		{id: "getn-id", plural: "getn-plural"},
-		{domain: "getd-domain", id: "getd-id"},
-		{domain: "getnd-domain", id: "getnd-id", plural: "getnd-plural"},
-		{id: "getc-id", context: `"getc-context"`},
-		{id: "getnc-id", plural: "getnc-plural", context: `"getnc-context"`},
-		{domain: "getdc-domain", id: "getdc-id", context: `"getdc-context"`},
-		{domain: "getndc-domain", id: "getndc-id", plural: "getndc-plural", context: `"getndc-context"`},
+	expected := []expectedTranslation{
+		{id: "get-id", location: "typed.go:6"},
+		{id: "getn-id", plural: "getn-plural", location: "typed.go:7"},
+		{domain: "getd-domain", id: "getd-id", location: "typed.go:8"},
+		{domain: "getnd-domain", id: "getnd-id", plural: "getnd-plural", location: "typed.go:9"},
+		{id: "getc-id", context: `"getc-context"`, location: "typed.go:10"},
+		{id: "getnc-id", plural: "getnc-plural", context: `"getnc-context"`, location: "typed.go:11"},
+		{domain: "getdc-domain", id: "getdc-id", context: `"getdc-context"`, location: "typed.go:12"},
+		{domain: "getndc-domain", id: "getndc-id", plural: "getndc-plural", context: `"getndc-context"`, location: "typed.go:13"},
 	}
 
 	if len(g.Data.Domains) != 5 {
 		t.Fatalf("got %d domains, want 5", len(g.Data.Domains))
 	}
-	for _, expected := range expected {
-		domain := g.Data.Domains[expected.domain]
+	for _, want := range expected {
+		domain := g.Data.Domains[want.domain]
 		if domain == nil {
 			domain = g.Data.Domains["default"]
 		}
-		if expected.context == "" {
-			translation := domain.Translations[expected.id]
-			if translation == nil {
-				t.Fatalf("missing translation %q in domain %q", expected.id, expected.domain)
-			}
-			if translation.MsgIDPlural != expected.plural || translation.Context != "" {
-				t.Errorf("translation %q = plural %q/context %q, want plural %q/context empty",
-					expected.id, translation.MsgIDPlural, translation.Context, expected.plural)
-			}
-			continue
+		var translation *Translation
+		if want.context == "" {
+			translation = domain.Translations[want.id]
+		} else {
+			translation = domain.ContextTranslations[want.context][want.id]
 		}
-		translation := domain.ContextTranslations[expected.context][expected.id]
 		if translation == nil {
-			t.Fatalf("missing contextual translation %q/%q", expected.context, expected.id)
+			t.Fatalf("missing translation %q in domain %q", want.id, want.domain)
 		}
-		if translation.MsgIDPlural != expected.plural || translation.Context != expected.context {
-			t.Errorf("translation %q = plural %q/context %q, want plural %q/context %q",
-				expected.id, translation.MsgIDPlural, translation.Context, expected.plural, expected.context)
+		if translation.MsgID != want.id ||
+			translation.MsgIDPlural != want.plural ||
+			translation.Context != want.context ||
+			len(translation.SourceLocations) != 1 ||
+			translation.SourceLocations[0] != want.location {
+			t.Errorf("translation = %#v, want id=%q plural=%q context=%q location=%q",
+				translation, want.id, want.plural, want.context, want.location)
 		}
 	}
 }
@@ -515,16 +369,25 @@ func example() {
 	if domain == nil {
 		t.Fatal("constant calls did not create default domain")
 	}
-	for _, id := range []string{
-		"first",
-		"first-alias",
-		"leftright",
-		"x",
-		"static",
-		"before",
-	} {
-		if domain.Translations[id] == nil {
-			t.Errorf("missing static translation %q", id)
+	expected := map[string]string{
+		"first":       "",
+		"first-alias": "",
+		"leftright":   "",
+		"x":           "",
+		"static":      "",
+		"before":      "",
+	}
+	if len(domain.Translations) != len(expected) {
+		t.Fatalf("got %d translations, want %d", len(domain.Translations), len(expected))
+	}
+	for id, plural := range expected {
+		translation := domain.Translations[id]
+		if translation == nil {
+			t.Fatalf("missing static translation %q", id)
+		}
+		if translation.MsgID != id || translation.MsgIDPlural != plural || translation.Context != "" {
+			t.Errorf("translation %q = %#v, want id=%q plural=%q without context",
+				id, translation, id, plural)
 		}
 	}
 	for _, id := range []string{"dynamic", "before mutation", "after mutation", "range"} {
@@ -562,66 +425,88 @@ func example() {
 			return
 		}
 
-		var calls []*ast.CallExpr
+		var call *ast.CallExpr
 		ast.Inspect(file, func(node ast.Node) bool {
-			call, ok := node.(*ast.CallExpr)
+			candidate, ok := node.(*ast.CallExpr)
 			if !ok {
 				return true
 			}
-			selector, ok := call.Fun.(*ast.SelectorExpr)
+			selector, ok := candidate.Fun.(*ast.SelectorExpr)
 			if ok && selector.Sel != nil && selector.Sel.Name == "Get" {
-				calls = append(calls, call)
+				call = candidate
 			}
 			return true
 		})
-		if len(calls) != 1 || len(calls[0].Args) == 0 {
+		if call == nil || len(call.Args) == 0 {
 			return
 		}
 
-		call := calls[0]
+		typeInfo := g.ImportedPackages["typed"].TypesInfo.Types[call.Args[0]]
+		expected, isConstant := "", false
+		if typeInfo.Value != nil && typeInfo.Value.Kind() == constant.String {
+			expected = constant.StringVal(typeInfo.Value)
+			isConstant = true
+		}
+
 		g.InspectCallExpr(call)
-		literal := g.resolveStringLiteral(call.Args[0], call.Pos(), nil)
-		if literal == nil {
+		if !isConstant {
 			if len(g.Data.Domains) != 0 {
 				t.Fatal("dynamic expression produced a translation")
 			}
 			return
 		}
-		value, err := strconv.Unquote(literal.Value)
-		if err != nil {
-			t.Fatalf("resolved literal %q is not a string: %v", literal.Value, err)
-		}
+
 		domain := g.Data.Domains["default"]
 		if domain == nil {
-			t.Fatal("resolved literal did not initialize the default domain")
+			t.Fatal("constant expression did not initialize the default domain")
 		}
-		translation := domain.Translations[value]
-		if translation == nil {
-			t.Fatalf("resolved literal %q was not extracted", value)
+		if len(domain.Translations) != 1 {
+			t.Fatalf("got %d translations, want one for %q", len(domain.Translations), expected)
+		}
+		translation := domain.Translations[expected]
+		if translation == nil || translation.MsgID != expected || translation.Context != "" || translation.MsgIDPlural != "" {
+			t.Fatalf("translation = %#v, want literal %q without plural or context", translation, expected)
 		}
 	})
 }
 
-func makeTypedASTCycle(t *testing.T, file *ast.File) {
+func makeTypedASTCycle(t *testing.T, g *GoFile, file *ast.File) {
 	t.Helper()
+	owner := g.ImportedPackages["typed"]
+	if owner == nil || owner.TypesInfo == nil {
+		t.Fatal("typed owner package has no type information")
+	}
 
 	declarations := make(map[string]*ast.ValueSpec, 2)
+	objects := make(map[string]types.Object, 2)
+	ast.Inspect(file, func(node ast.Node) bool {
+		spec, ok := node.(*ast.ValueSpec)
+		if !ok {
+			return true
+		}
+		for _, name := range spec.Names {
+			if name.Name != "cyclicA" && name.Name != "cyclicB" {
+				continue
+			}
+			object := owner.TypesInfo.Defs[name]
+			if object == nil || object.Pkg() == nil || object.Pkg().Path() != "typed" {
+				t.Fatalf("%s is not a type-checked owner-package object", name.Name)
+			}
+			declarations[name.Name] = spec
+			objects[name.Name] = object
+		}
+		return true
+	})
+
 	references := make(map[string]*ast.Ident, 2)
 	ast.Inspect(file, func(node ast.Node) bool {
-		switch node := node.(type) {
-		case *ast.ValueSpec:
-			for _, name := range node.Names {
-				if name.Name == "cyclicA" || name.Name == "cyclicB" {
-					declarations[name.Name] = node
-				}
-			}
-		case *ast.Ident:
-			spec, ok := declarations[node.Name]
-			if ok && node.Obj != nil && node.Obj.Decl == spec {
-				if slices.Contains(spec.Names, node) {
-					return true
-				}
-				references[node.Name] = node
+		ident, ok := node.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		for name, object := range objects {
+			if ident.Name == name && owner.TypesInfo.Uses[ident] == object {
+				references[name] = ident
 			}
 		}
 		return true
@@ -629,7 +514,7 @@ func makeTypedASTCycle(t *testing.T, file *ast.File) {
 
 	for _, name := range []string{"cyclicA", "cyclicB"} {
 		if declarations[name] == nil || references[name] == nil {
-			t.Fatalf("failed to find typed AST cycle node %s", name)
+			t.Fatalf("failed to find type-checked cycle node %s", name)
 		}
 	}
 	declarations["cyclicA"].Values = []ast.Expr{references["cyclicB"]}
@@ -642,9 +527,6 @@ func TestGoFile_InspectCallExpr_TypedASTMutation(t *testing.T) {
 import "github.com/leonelquinteros/gotext"
 
 func example() {
-	unrelated := "unrelated"
-	unrelated = "changed unrelated"
-	_ = unrelated
 	before := "message before mutation"
 	gotext.Get(before)
 
@@ -660,15 +542,21 @@ func example() {
 	g, file := newTypedGoFile(t, source)
 	inspectTypedCalls(g, file)
 
-	translations := g.Data.Domains["default"].Translations
+	domain := g.Data.Domains["default"]
+	if domain == nil {
+		t.Fatal("mutation test did not initialize the default domain")
+	}
+	translations := domain.Translations
 	if len(translations) != 2 {
 		t.Fatalf("got %d translations, want 2", len(translations))
 	}
-	if _, ok := translations["message before mutation"]; !ok {
-		t.Error("unmodified identifier before its call was not extracted")
+	before := translations["message before mutation"]
+	if before == nil || before.MsgID != "message before mutation" {
+		t.Errorf("unmodified identifier before its call = %#v, want literal metadata", before)
 	}
-	if _, ok := translations["message before later mutation"]; !ok {
-		t.Error("identifier mutated after its call was not extracted")
+	afterCall := translations["message before later mutation"]
+	if afterCall == nil || afterCall.MsgID != "message before later mutation" {
+		t.Errorf("identifier mutated after its call = %#v, want literal metadata", afterCall)
 	}
 	if _, ok := translations["message after mutation"]; ok {
 		t.Error("identifier mutated before its call was extracted")
@@ -687,41 +575,53 @@ var later = "later call"
 
 func example() {
 	gotext.Get(cyclicA)
-	gotext.GetNC("id", "plural", cyclicB, contextAfterCycle)
+	gotext.GetNC("id", "plural", 2, "context after cycle", cyclicB, contextAfterCycle)
 	gotext.Get(later)
 }`
 
 	g, file := newTypedGoFile(t, source)
-	makeTypedASTCycle(t, file)
+	makeTypedASTCycle(t, g, file)
 	inspectTypedCalls(g, file)
 
 	domain := g.Data.Domains["default"]
+	if domain == nil {
+		t.Fatal("cycle test did not initialize the default domain")
+	}
+	if len(domain.Translations) != 1 {
+		t.Fatalf("got %d uncontexted translations, want one", len(domain.Translations))
+	}
 	if _, ok := domain.Translations["cyclicA"]; ok {
 		t.Error("cyclic identifier was extracted")
 	}
+	if _, ok := domain.Translations["cyclicB"]; ok {
+		t.Error("cyclic identifier was extracted as a later argument")
+	}
+	later := domain.Translations["later call"]
+	if later == nil || later.MsgID != "later call" {
+		t.Fatalf("later translation = %#v, want literal call metadata", later)
+	}
+
 	contextTranslations := domain.ContextTranslations[`"context after cycle"`]
-	translation, ok := contextTranslations["id"]
-	if !ok {
+	if len(contextTranslations) != 1 {
+		t.Fatalf("got %d contextual translations, want one", len(contextTranslations))
+	}
+	translation := contextTranslations["id"]
+	if translation == nil {
 		t.Fatal("later arguments were not extracted after a cyclic identifier")
 	}
-	if translation.Context != `"context after cycle"` {
-		t.Errorf("context = %q, want %q", translation.Context, `"context after cycle"`)
-	}
-	if _, ok := domain.Translations["later call"]; !ok {
-		t.Error("later call was not extracted after a cyclic identifier")
-	}
-	if len(domain.Translations) != 1 || len(contextTranslations) != 1 {
-		t.Fatalf("got %d uncontexted and %d contextual translations, want 1 each",
-			len(domain.Translations), len(contextTranslations))
+	if translation.MsgID != "id" ||
+		translation.MsgIDPlural != "plural" ||
+		translation.Context != `"context after cycle"` {
+		t.Errorf("contextual translation = %#v, want id/plural/context metadata", translation)
 	}
 }
 
-func TestGoFile_ResolveStringLiteral_UsesOwningPackageSyntax(t *testing.T) {
+func TestGoFile_InspectCallExpr_UsesOwningPackageSyntax(t *testing.T) {
 	const source = `package typed
 
 import "github.com/leonelquinteros/gotext"
 
-var crossFile = "cross-file"
+var crossFile = "temporary declaration"
 
 func example() {
 	gotext.Get(crossFile)
@@ -729,37 +629,37 @@ func example() {
 
 	g, file := newTypedGoFile(t, source)
 	var call *ast.CallExpr
-	var getter *ast.Ident
 	var declaration *ast.GenDecl
-	for _, decl := range file.Decls {
-		genDecl, ok := decl.(*ast.GenDecl)
-		if !ok || genDecl.Tok != token.VAR {
-			continue
-		}
-		declaration = genDecl
-		break
-	}
 	ast.Inspect(file, func(node ast.Node) bool {
 		switch node := node.(type) {
 		case *ast.CallExpr:
-			call = node
-		case *ast.SelectorExpr:
-			if node.Sel != nil && node.Sel.Name == "Get" {
-				getter = node.Sel
+			if selector, ok := node.Fun.(*ast.SelectorExpr); ok &&
+				selector.Sel != nil && selector.Sel.Name == "Get" {
+				call = node
+			}
+		case *ast.GenDecl:
+			if node.Tok == token.VAR {
+				declaration = node
 			}
 		}
 		return true
 	})
-	if call == nil || getter == nil || declaration == nil {
-		t.Fatal("failed to find getter call and package-level declaration")
+	if call == nil || declaration == nil {
+		t.Fatal("failed to find typed getter call and temporary declaration")
 	}
 
-	gotextObject := g.GetType(getter)
-	if gotextObject == nil || gotextObject.Pkg() == nil {
-		t.Fatal("getter has no owning package")
+	declIndex := -1
+	for index, decl := range file.Decls {
+		if decl == declaration {
+			declIndex = index
+			break
+		}
 	}
-	declIndex := slices.Index(file.Decls, ast.Decl(declaration))
+	if declIndex < 0 {
+		t.Fatal("temporary declaration is not part of the owner file")
+	}
 	file.Decls = append(file.Decls[:declIndex], file.Decls[declIndex+1:]...)
+
 	declarationFile, err := goparser.ParseFile(g.FileSet, "declaration.go", `package typed
 
 var crossFile = "cross-file"
@@ -767,107 +667,123 @@ var crossFile = "cross-file"
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	typesInfo := &types.Info{
-		Types: make(map[ast.Expr]types.TypeAndValue),
-		Defs:  make(map[*ast.Ident]types.Object),
-		Uses:  make(map[*ast.Ident]types.Object),
+	gotextPackage := g.ImportedPackages["gotext"]
+	if gotextPackage == nil || gotextPackage.Types == nil {
+		t.Fatal("typed fixture has no type-checked gettext package")
 	}
-	if _, err := (&types.Config{
-		Importer: typedASTImporter{pkg: gotextObject.Pkg()},
-	}).Check("typed", g.FileSet, []*ast.File{file, declarationFile}, typesInfo); err != nil {
+	ownerInfo := typedTypesInfo()
+	ownerTypes, err := (&types.Config{
+		Importer: typedASTImporter{packages: map[string]*types.Package{
+			typedGotextPackagePath: gotextPackage.Types,
+		}},
+	}).Check("typed", g.FileSet, []*ast.File{file, declarationFile}, ownerInfo)
+	if err != nil {
 		t.Fatal(err)
 	}
 	ownerPackage := g.ImportedPackages["typed"]
-	if ownerPackage == nil {
-		t.Fatal("typed package metadata is missing")
-	}
 	ownerPackage.Syntax = []*ast.File{file, declarationFile}
-	ownerPackage.TypesInfo = typesInfo
+	ownerPackage.Types = ownerTypes
+	ownerPackage.TypesInfo = ownerInfo
 
-	var use, definition *ast.Ident
-	if len(call.Args) > 0 {
-		use, _ = call.Args[0].(*ast.Ident)
-	}
+	var definition *ast.Ident
 	ast.Inspect(declarationFile, func(node ast.Node) bool {
 		ident, ok := node.(*ast.Ident)
-		if ok && ident.Name == "crossFile" {
+		if ok && ident.Name == "crossFile" && ownerInfo.Defs[ident] != nil {
 			definition = ident
 			return false
 		}
 		return true
 	})
-	if use == nil || definition == nil {
-		t.Fatal("failed to find type-checked getter argument and declaration")
+	if definition == nil {
+		t.Fatal("cross-file definition is not type-checked")
 	}
-	object := g.GetType(definition)
-	if object == nil || object.Pkg() == nil {
-		t.Fatal("cross-file identifier has no owning package object")
+	ownerObject := ownerInfo.Defs[definition]
+	if ownerObject == nil || ownerObject.Pkg() == nil || ownerObject.Pkg().Path() != "typed" {
+		t.Fatal("cross-file definition has no typed owner package")
 	}
+	var use *ast.Ident
+	ast.Inspect(file, func(node ast.Node) bool {
+		ident, ok := node.(*ast.Ident)
+		if ok && ident.Name == "crossFile" && ownerInfo.Uses[ident] == ownerObject {
+			use = ident
+			return false
+		}
+		return true
+	})
+	if use == nil {
+		t.Fatal("cross-file use is not linked to the owner-package object")
+	}
+	// A cross-file identifier cannot retain the parser's same-file ast.Object.
+	// Force production lookup through the jointly type-checked owner package.
+	use.Obj = nil
 
-	unrelatedFile, err := goparser.ParseFile(token.NewFileSet(), "unrelated.go", `package unrelated
+	foreignFileSet := token.NewFileSet()
+	foreignFile, err := goparser.ParseFile(foreignFileSet, "unrelated.go", `package unrelated
 
-var crossFile = "unrelated declaration"
+var crossFile = "foreign declaration"
 
 func mutate() {
-	crossFile = "unrelated mutation"
+	crossFile = "foreign mutation"
 }
 `, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	var unrelatedDeclaration, unrelatedMutation *ast.Ident
-	ast.Inspect(unrelatedFile, func(node ast.Node) bool {
-		switch node := node.(type) {
-		case *ast.ValueSpec:
-			if len(node.Names) > 0 {
-				unrelatedDeclaration = node.Names[0]
-			}
-		case *ast.AssignStmt:
-			if len(node.Lhs) > 0 {
-				unrelatedMutation, _ = node.Lhs[0].(*ast.Ident)
-				if unrelatedMutation != nil {
-					unrelatedMutation.NamePos = token.Pos(1)
-				}
-			}
+	foreignInfo := typedTypesInfo()
+	foreignTypes, err := (&types.Config{}).Check(
+		"example.com/unrelated",
+		foreignFileSet,
+		[]*ast.File{foreignFile},
+		foreignInfo,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var foreignDefinition, foreignMutation *ast.Ident
+	ast.Inspect(foreignFile, func(node ast.Node) bool {
+		ident, ok := node.(*ast.Ident)
+		if !ok || ident.Name != "crossFile" {
+			return true
+		}
+		if foreignInfo.Defs[ident] != nil {
+			foreignDefinition = ident
+		}
+		if foreignInfo.Uses[ident] != nil {
+			foreignMutation = ident
 		}
 		return true
 	})
-	if unrelatedDeclaration == nil || unrelatedMutation == nil {
-		t.Fatal("failed to find unrelated declarations")
+	if foreignDefinition == nil || foreignMutation == nil {
+		t.Fatal("foreign fixture objects are not type-checked")
 	}
-	unrelatedPackage := &packages.Package{
-		PkgPath: "example.com/unrelated",
-		Syntax:  []*ast.File{unrelatedFile},
-		TypesInfo: &types.Info{
-			Defs: map[*ast.Ident]types.Object{
-				unrelatedDeclaration: object,
-			},
-			Uses: map[*ast.Ident]types.Object{
-				unrelatedMutation: object,
-			},
-		},
+	foreignObject := foreignInfo.Defs[foreignDefinition]
+	if foreignObject == nil || foreignObject == ownerObject ||
+		foreignObject.Pkg() == nil || foreignObject.Pkg().Path() != "example.com/unrelated" ||
+		foreignInfo.Uses[foreignMutation] != foreignObject {
+		t.Fatal("foreign fixture does not contain an independent package object")
 	}
-
-	savedPackages := g.ImportedPackages
-	g.ImportedPackages = map[string]*packages.Package{"unrelated": unrelatedPackage}
-	if _, _, ok := g.declarationForObject(object); ok {
-		t.Fatal("unrelated package declaration was scanned")
-	}
-	g.ImportedPackages = savedPackages
-	g.ImportedPackages["unrelated"] = unrelatedPackage
-
-	if g.isMutatedBefore(object, call.Pos()) {
-		t.Fatal("unrelated package mutation was scanned")
-	}
-	literal := g.resolveStringLiteral(use, call.Pos(), nil)
-	if literal == nil || literal.Value != `"cross-file"` {
-		t.Fatalf("resolved literal = %v, want %q", literal, `"cross-file"`)
+	g.ImportedPackages["unrelated"] = &packages.Package{
+		Name:      "unrelated",
+		PkgPath:   "example.com/unrelated",
+		Syntax:    []*ast.File{foreignFile},
+		Types:     foreignTypes,
+		TypesInfo: foreignInfo,
 	}
 
 	g.InspectCallExpr(call)
 	domain := g.Data.Domains["default"]
-	if domain == nil || domain.Translations["cross-file"] == nil {
-		t.Fatal("cross-file declaration was not extracted")
+	if domain == nil {
+		t.Fatal("cross-file call did not initialize the default domain")
+	}
+	if len(domain.Translations) != 1 {
+		t.Fatalf("got %d translations, want one owner-package translation", len(domain.Translations))
+	}
+	translation := domain.Translations["cross-file"]
+	if translation == nil || translation.MsgID != "cross-file" ||
+		len(translation.SourceLocations) != 1 || translation.SourceLocations[0] != "typed.go:8" {
+		t.Fatalf("translation = %#v, want owner declaration value and call location", translation)
+	}
+	if _, ok := domain.Translations["foreign declaration"]; ok {
+		t.Fatal("foreign-package declaration was extracted")
 	}
 }

--- a/cli/xgotext/parser/pkg-tree/golang.go
+++ b/cli/xgotext/parser/pkg-tree/golang.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"sync"
 
 	"golang.org/x/tools/go/packages"
 
@@ -17,8 +18,9 @@ import (
 func ParsePkgTree(pkgPath string, data *parser.DomainMap, verbose bool) error {
 	basePath, err := os.Getwd()
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
+	resetPackageCache()
 	return pkgParser(pkgPath, basePath, data, verbose)
 }
 
@@ -28,13 +30,14 @@ func pkgParser(dirPath, basePath string, data *parser.DomainMap, verbose bool) e
 		return err
 	}
 
-	for _, pkg := range filterPkgs(mainPkg) {
+	pkgs, cache := filterPkgsScoped(mainPkg)
+	for _, pkg := range pkgs {
 		if verbose {
 			fmt.Println(pkg.ID)
 		}
 		for _, node := range pkg.Syntax {
 			file := GoFile{
-				parser.GoFile{
+				GoFile: parser.GoFile{
 					FilePath: pkg.Fset.Position(node.Package).Filename,
 					BasePath: basePath,
 					Data:     data,
@@ -44,6 +47,7 @@ func pkgParser(dirPath, basePath string, data *parser.DomainMap, verbose bool) e
 						pkg.Name: pkg,
 					},
 				},
+				packageCache: cache,
 			}
 
 			ast.Inspect(node, file.InspectFile)
@@ -53,7 +57,22 @@ func pkgParser(dirPath, basePath string, data *parser.DomainMap, verbose bool) e
 	return nil
 }
 
-var pkgCache = make(map[string]*packages.Package)
+var (
+	pkgCache   = make(map[string]*packages.Package)
+	pkgCacheMu sync.RWMutex
+)
+
+func resetPackageCache() {
+	pkgCacheMu.Lock()
+	pkgCache = make(map[string]*packages.Package)
+	pkgCacheMu.Unlock()
+}
+
+func setPackageCache(cache map[string]*packages.Package) {
+	pkgCacheMu.Lock()
+	pkgCache = cache
+	pkgCacheMu.Unlock()
+}
 
 func loadPackage(name string) (*packages.Package, error) {
 	fileSet := token.NewFileSet()
@@ -72,26 +91,78 @@ func loadPackage(name string) (*packages.Package, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := packageDiagnostics(pkgs); err != nil {
+		return nil, err
+	}
+	if len(pkgs) == 0 {
+		return nil, fmt.Errorf("no packages found for %q", name)
+	}
 
 	return pkgs[0], nil
 }
 
+func packageDiagnostics(pkgs []*packages.Package) error {
+	seen := make(map[*packages.Package]bool, len(pkgs))
+	var visit func(*packages.Package) error
+	visit = func(pkg *packages.Package) error {
+		if pkg == nil {
+			return fmt.Errorf("package loader returned a nil package")
+		}
+		if seen[pkg] {
+			return nil
+		}
+		seen[pkg] = true
+		if len(pkg.Errors) > 0 {
+			return fmt.Errorf("package %q has diagnostics: %v", pkg.ID, pkg.Errors)
+		}
+		for _, importedPkg := range pkg.Imports {
+			if err := visit(importedPkg); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for _, pkg := range pkgs {
+		if err := visit(pkg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func filterPkgs(pkg *packages.Package) []*packages.Package {
-	result := filterPkgsRec(pkg)
+	result, cache := filterPkgsScoped(pkg)
+	setPackageCache(cache)
 	return result
 }
 
-func filterPkgsRec(pkg *packages.Package) []*packages.Package {
+func filterPkgsScoped(pkg *packages.Package) ([]*packages.Package, map[string]*packages.Package) {
+	cache := make(map[string]*packages.Package, 100)
+	return filterPkgsRecWithCache(pkg, cache), cache
+}
+
+func filterPkgsRecWithCache(pkg *packages.Package, cache map[string]*packages.Package) []*packages.Package {
+	if pkg == nil {
+		return nil
+	}
+	if _, ok := cache[pkg.ID]; ok {
+		return nil
+	}
+	cache[pkg.ID] = pkg
+
 	result := make([]*packages.Package, 0, 100)
-	pkgCache[pkg.ID] = pkg
 	for _, importedPkg := range pkg.Imports {
+		if importedPkg == nil {
+			continue
+		}
 		if importedPkg.ID == "github.com/leonelquinteros/gotext" {
 			result = append(result, pkg)
 		}
-		if _, ok := pkgCache[importedPkg.ID]; ok {
+		if _, ok := cache[importedPkg.ID]; ok {
 			continue
 		}
-		result = append(result, filterPkgsRec(importedPkg)...)
+		result = append(result, filterPkgsRecWithCache(importedPkg, cache)...)
 	}
 	return result
 }
@@ -99,11 +170,21 @@ func filterPkgsRec(pkg *packages.Package) []*packages.Package {
 // GoFile handles the parsing of one go file
 type GoFile struct {
 	parser.GoFile
+	packageCache map[string]*packages.Package
 }
 
 // GetPackage loads module by name
 func (g *GoFile) GetPackage(name string) (*packages.Package, error) {
+	if g.packageCache != nil {
+		if pkg, ok := g.packageCache[name]; ok {
+			return pkg, nil
+		}
+		return nil, fmt.Errorf("not found in cache")
+	}
+
+	pkgCacheMu.RLock()
 	pkg, ok := pkgCache[name]
+	pkgCacheMu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("not found in cache")
 	}

--- a/cli/xgotext/parser/pkg-tree/golang_test.go
+++ b/cli/xgotext/parser/pkg-tree/golang_test.go
@@ -1,11 +1,15 @@
 package pkgtree
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/leonelquinteros/gotext/cli/xgotext/parser"
+
+	"golang.org/x/tools/go/packages"
 )
 
 func TestParsePkgTree(t *testing.T) {
@@ -73,4 +77,132 @@ EOL`, "multline\nending with EOL\n", "type alias", "locale constructor call",
 	if _, ok := data.Domains[defaultDomain].Translations["message with a dynamic domain"]; ok {
 		t.Error("dynamic domain should not be extracted")
 	}
+}
+
+func TestLoadPackageReturnsErrorForEmptyResults(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+	if _, err := loadPackage(missing); err == nil {
+		t.Fatal("loadPackage unexpectedly succeeded without a package")
+	}
+}
+
+func TestLoadPackageReturnsPackageDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/broken\n\ngo 1.27\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "broken.go"), []byte("package broken\n\nfunc broken(\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := loadPackage(root); err == nil {
+		t.Fatal("loadPackage unexpectedly ignored package diagnostics")
+	}
+}
+
+func TestFilterPkgsCacheScope(t *testing.T) {
+	const gotextID = "github.com/leonelquinteros/gotext"
+	firstGotext := &packages.Package{ID: gotextID}
+	first := &packages.Package{
+		ID: "example.com/first",
+		Imports: map[string]*packages.Package{
+			gotextID: firstGotext,
+		},
+	}
+	secondGotext := &packages.Package{ID: gotextID}
+	second := &packages.Package{
+		ID: "example.com/second",
+		Imports: map[string]*packages.Package{
+			gotextID: secondGotext,
+		},
+	}
+
+	if got := filterPkgs(first); len(got) != 1 || got[0] != first {
+		t.Fatalf("filterPkgs(first) = %v, want first package", got)
+	}
+	if got := filterPkgs(second); len(got) != 1 || got[0] != second {
+		t.Fatalf("filterPkgs(second) = %v, want second package", got)
+	}
+	g := &GoFile{}
+	if got, err := g.GetPackage(gotextID); err != nil || got != secondGotext {
+		t.Fatalf("cached gotext package = %v, %v; want second graph package", got, err)
+	}
+}
+
+func TestParsePkgTreeIndependentGraphs(t *testing.T) {
+	repoRoot := repositoryRoot(t)
+	firstRoot := writeTestGraph(t, repoRoot, "first graph")
+	secondRoot := writeTestGraph(t, repoRoot, "second graph")
+
+	firstData := &parser.DomainMap{Default: "default"}
+	if err := ParsePkgTree(firstRoot, firstData, false); err != nil {
+		t.Fatalf("first ParsePkgTree: %v", err)
+	}
+	if !hasTestTranslation(firstData, "first graph") {
+		t.Fatal("first graph translation was not extracted")
+	}
+
+	secondData := &parser.DomainMap{Default: "default"}
+	if err := ParsePkgTree(secondRoot, secondData, false); err != nil {
+		t.Fatalf("second ParsePkgTree: %v", err)
+	}
+	if !hasTestTranslation(secondData, "second graph") {
+		t.Fatal("second graph translation was not extracted")
+	}
+	if hasTestTranslation(secondData, "first graph") {
+		t.Fatal("second graph reused a package from the first graph")
+	}
+}
+
+func hasTestTranslation(data *parser.DomainMap, message string) bool {
+	domain, ok := data.Domains["default"]
+	if !ok || domain == nil {
+		return false
+	}
+	_, ok = domain.Translations[message]
+	return ok
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", ".."))
+}
+
+func writeTestGraph(t *testing.T, repoRoot, message string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte(fmt.Sprintf(`module example.com/repeated
+
+go 1.27
+
+require github.com/leonelquinteros/gotext v0.0.0
+
+replace github.com/leonelquinteros/gotext => %s
+`, repoRoot)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "shared"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte(`package app
+
+import "example.com/repeated/shared"
+
+func Run() { shared.Run() }
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "shared", "shared.go"), []byte(fmt.Sprintf(`package shared
+
+import "github.com/leonelquinteros/gotext"
+
+func Run() { gotext.Get(%q) }
+`, message)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return root
 }

--- a/cli/xgotext/parser/pkg-tree/golang_test.go
+++ b/cli/xgotext/parser/pkg-tree/golang_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/leonelquinteros/gotext/cli/xgotext/parser"
@@ -17,15 +18,9 @@ func TestParsePkgTree(t *testing.T) {
 	data := &parser.DomainMap{
 		Default: defaultDomain,
 	}
-	currentPath, err := os.Getwd()
-	pkgPath := filepath.Join(filepath.Dir(filepath.Dir(currentPath)), "fixtures")
-	println(pkgPath)
-	if err != nil {
-		t.Error(err)
-	}
-	err = ParsePkgTree(pkgPath, data, true)
-	if err != nil {
-		t.Error(err)
+	pkgPath := filepath.Join(repositoryRoot(t), "cli", "xgotext", "fixtures")
+	if err := ParsePkgTree(pkgPath, data, true); err != nil {
+		t.Fatal(err)
 	}
 
 	translations := []string{"inside sub package", "My text on 'domain-name' domain", "alias call", "Singular", "SingularVar", "translate package", "translate sub package", "inside dummy",
@@ -78,8 +73,7 @@ EOL`, "multline\nending with EOL\n", "type alias", "locale constructor call",
 		t.Error("dynamic domain should not be extracted")
 	}
 }
-
-func TestLoadPackageReturnsErrorForEmptyResults(t *testing.T) {
+func TestLoadPackageReturnsErrorForMissingRoot(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "missing")
 	if _, err := loadPackage(missing); err == nil {
 		t.Fatal("loadPackage unexpectedly succeeded without a package")
@@ -95,8 +89,12 @@ func TestLoadPackageReturnsPackageDiagnostics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := loadPackage(root); err == nil {
+	_, err := loadPackage(root)
+	if err == nil {
 		t.Fatal("loadPackage unexpectedly ignored package diagnostics")
+	}
+	if !strings.Contains(err.Error(), `package "example.com/broken" has diagnostics`) {
+		t.Fatalf("loadPackage error = %v, want package diagnostics", err)
 	}
 }
 
@@ -131,8 +129,8 @@ func TestFilterPkgsCacheScope(t *testing.T) {
 
 func TestParsePkgTreeIndependentGraphs(t *testing.T) {
 	repoRoot := repositoryRoot(t)
-	firstRoot := writeTestGraph(t, repoRoot, "first graph")
-	secondRoot := writeTestGraph(t, repoRoot, "second graph")
+	firstRoot := writeTestGraph(t, repoRoot, "example.com/first", "first graph")
+	secondRoot := writeTestGraph(t, repoRoot, "example.com/second", "second graph")
 
 	firstData := &parser.DomainMap{Default: "default"}
 	if err := ParsePkgTree(firstRoot, firstData, false); err != nil {
@@ -140,6 +138,9 @@ func TestParsePkgTreeIndependentGraphs(t *testing.T) {
 	}
 	if !hasTestTranslation(firstData, "first graph") {
 		t.Fatal("first graph translation was not extracted")
+	}
+	if hasTestTranslation(firstData, "second graph") {
+		t.Fatal("first graph reused a package from the second graph")
 	}
 
 	secondData := &parser.DomainMap{Default: "default"}
@@ -152,6 +153,40 @@ func TestParsePkgTreeIndependentGraphs(t *testing.T) {
 	if hasTestTranslation(secondData, "first graph") {
 		t.Fatal("second graph reused a package from the first graph")
 	}
+}
+func writeTestGraph(t *testing.T, repoRoot, modulePath, message string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte(fmt.Sprintf(`module %s
+
+go 1.27
+
+require github.com/leonelquinteros/gotext v0.0.0
+
+replace github.com/leonelquinteros/gotext => %s
+`, modulePath, repoRoot)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "shared"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte(fmt.Sprintf(`package app
+
+import %q
+
+func Run() { shared.Run() }
+`, modulePath+"/shared")), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "shared", "shared.go"), []byte(fmt.Sprintf(`package shared
+
+import "github.com/leonelquinteros/gotext"
+
+func Run() { gotext.Get(%q) }
+`, message)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return root
 }
 
 func hasTestTranslation(data *parser.DomainMap, message string) bool {
@@ -170,39 +205,4 @@ func repositoryRoot(t *testing.T) string {
 		t.Fatal("runtime.Caller failed")
 	}
 	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", ".."))
-}
-
-func writeTestGraph(t *testing.T, repoRoot, message string) string {
-	t.Helper()
-	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte(fmt.Sprintf(`module example.com/repeated
-
-go 1.27
-
-require github.com/leonelquinteros/gotext v0.0.0
-
-replace github.com/leonelquinteros/gotext => %s
-`, repoRoot)), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Mkdir(filepath.Join(root, "shared"), 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte(`package app
-
-import "example.com/repeated/shared"
-
-func Run() { shared.Run() }
-`), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "shared", "shared.go"), []byte(fmt.Sprintf(`package shared
-
-import "github.com/leonelquinteros/gotext"
-
-func Run() { gotext.Get(%q) }
-`, message)), 0644); err != nil {
-		t.Fatal(err)
-	}
-	return root
 }

--- a/domain.go
+++ b/domain.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
-	"regexp"
+	"maps"
 	"sort"
 	"strconv"
 	"strings"
@@ -100,29 +100,132 @@ func NewDomain() *Domain {
 	return domain
 }
 
+func cloneRefs(refs []string) []string {
+	if refs == nil {
+		return nil
+	}
+
+	owned := make([]string, len(refs))
+	copy(owned, refs)
+	return owned
+}
+
+func cloneHeaderMap(headers HeaderMap) HeaderMap {
+	if headers == nil {
+		return nil
+	}
+
+	owned := make(HeaderMap, len(headers))
+	for key, values := range headers {
+		owned[key] = cloneRefs(values)
+	}
+	return owned
+}
+
+func cloneTranslation(trans *Translation) *Translation {
+	if trans == nil {
+		return nil
+	}
+
+	owned := NewTranslation()
+	owned.ID = trans.ID
+	owned.PluralID = trans.PluralID
+	owned.dirty = trans.dirty
+	owned.Refs = cloneRefs(trans.Refs)
+
+	maps.Copy(owned.Trs, trans.Trs)
+
+	return owned
+}
+
+func cloneTranslations(translations map[string]*Translation) map[string]*Translation {
+	if translations == nil {
+		return nil
+	}
+
+	owned := make(map[string]*Translation, len(translations))
+	for id, trans := range translations {
+		owned[id] = cloneTranslation(trans)
+	}
+	return owned
+}
+
+func cloneContextTranslations(contexts map[string]map[string]*Translation) map[string]map[string]*Translation {
+	if contexts == nil {
+		return nil
+	}
+
+	owned := make(map[string]map[string]*Translation, len(contexts))
+	for context, translations := range contexts {
+		if translations == nil {
+			owned[context] = nil
+			continue
+		}
+
+		contextOwned := make(map[string]*Translation, len(translations))
+		for id, trans := range translations {
+			contextOwned[id] = cloneTranslation(trans)
+		}
+		owned[context] = contextOwned
+	}
+	return owned
+}
+
+func (do *Domain) hasTranslation(id string) bool {
+	do.trMutex.RLock()
+	defer do.trMutex.RUnlock()
+
+	if do.translations == nil {
+		return false
+	}
+	trans, ok := do.translations[id]
+	return ok && trans != nil
+}
+
+func (do *Domain) hasContextTranslation(id, context string) bool {
+	do.trMutex.RLock()
+	defer do.trMutex.RUnlock()
+
+	if do.contextTranslations == nil {
+		return false
+	}
+	translations, ok := do.contextTranslations[context]
+	if !ok || translations == nil {
+		return false
+	}
+	trans, ok := translations[id]
+	return ok && trans != nil
+}
+
 // SetPluralResolver sets a custom plural resolver function
 func (do *Domain) SetPluralResolver(f func(int) int) {
+	do.pluralMutex.Lock()
+	defer do.pluralMutex.Unlock()
+
 	do.customPluralResolver = f
 }
 
 func (do *Domain) pluralForm(n int) int {
-	// do we really need locking here? not sure how this plurals.Expression works, so sticking with it for now
+	// Snapshot plural state before calling an expression or custom resolver.
 	do.pluralMutex.RLock()
-	defer do.pluralMutex.RUnlock()
+	pluralforms := do.pluralforms
+	customPluralResolver := do.customPluralResolver
+	do.pluralMutex.RUnlock()
+
+	if pluralforms != nil {
+		return pluralforms.Eval(uint32(n))
+	}
 
 	// Failure fallback
-	if do.pluralforms == nil {
-		if do.customPluralResolver != nil {
-			return do.customPluralResolver(n)
-		}
-
-		/* Use the Germanic plural rule.  */
-		if n == 1 {
-			return 0
-		}
-		return 1
+	if customPluralResolver != nil {
+		return customPluralResolver(n)
 	}
-	return do.pluralforms.Eval(uint32(n))
+
+	/* Use the Germanic plural rule.  */
+	if n == 1 {
+		return 0
+	}
+	return 1
 }
 
 // parseHeaders retrieves data from previously parsed headers. it's called by both Mo and Po when parsing
@@ -136,18 +239,16 @@ func (do *Domain) parseHeaders() {
 	languageKey := "Language"
 	pluralFormsKey := "Plural-Forms"
 
-	rawLines := strings.Split(raw, "\n")
-	for _, line := range rawLines {
+	for line := range strings.SplitSeq(raw, "\n") {
 		if len(line) == 0 {
 			continue
 		}
 
-		colonIdx := strings.Index(line, ":")
-		if colonIdx < 0 {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
 			continue
 		}
 
-		key := line[:colonIdx]
 		lowerKey := strings.ToLower(key)
 		if lowerKey == strings.ToLower(languageKey) {
 			languageKey = key
@@ -155,7 +256,7 @@ func (do *Domain) parseHeaders() {
 			pluralFormsKey = key
 		}
 
-		value := strings.TrimSpace(line[colonIdx+1:])
+		value = strings.TrimSpace(value)
 		do.Headers.Add(key, value)
 	}
 
@@ -168,22 +269,18 @@ func (do *Domain) parseHeaders() {
 		return
 	}
 
-	// Split plural form header value
-	pfs := strings.Split(do.PluralForms, ";")
-
-	// Parse values
-	for _, i := range pfs {
-		vs := strings.SplitN(i, "=", 2)
-		if len(vs) != 2 {
+	for i := range strings.SplitSeq(do.PluralForms, ";") {
+		key, value, ok := strings.Cut(i, "=")
+		if !ok {
 			continue
 		}
 
-		switch strings.TrimSpace(vs[0]) {
+		switch strings.TrimSpace(key) {
 		case "nplurals":
-			do.nplurals, _ = strconv.Atoi(vs[1])
+			do.nplurals, _ = strconv.Atoi(value)
 
 		case "plural":
-			do.plural = vs[1]
+			do.plural = value
 
 			if expr, err := plurals.Compile(do.plural); err == nil {
 				do.pluralforms = expr
@@ -221,17 +318,19 @@ func (do *Domain) DropStaleTranslations() {
 
 // SetRefs set source references for a given translation
 func (do *Domain) SetRefs(str string, refs []string) {
+	ownedRefs := cloneRefs(refs)
+
 	do.trMutex.Lock()
 	do.pluralMutex.Lock()
 	defer do.trMutex.Unlock()
 	defer do.pluralMutex.Unlock()
 
-	if trans, ok := do.translations[str]; ok {
-		trans.Refs = refs
+	if trans, ok := do.translations[str]; ok && trans != nil {
+		trans.SetRefs(ownedRefs)
 	} else {
-		trans = NewTranslation()
+		trans := NewTranslation()
 		trans.ID = str
-		trans.SetRefs(refs)
+		trans.SetRefs(ownedRefs)
 		do.translations[str] = trans
 	}
 }
@@ -243,8 +342,8 @@ func (do *Domain) GetRefs(str string) []string {
 	defer do.trMutex.RUnlock()
 
 	if do.translations != nil {
-		if trans, ok := do.translations[str]; ok {
-			return trans.Refs
+		if trans, ok := do.translations[str]; ok && trans != nil {
+			return cloneRefs(trans.Refs)
 		}
 	}
 	return nil
@@ -324,18 +423,22 @@ func (do *Domain) SetN(id, plural string, n int, str string) {
 // GetN retrieves the (N)th plural form of Translation for the given string.
 // Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
 func (do *Domain) GetN(str, plural string, n int, vars ...any) string {
+	// Get plural form before acquiring the translation lock so a custom
+	// resolver is never called while a project lock is held.
+	pluralForm := do.pluralForm(n)
+
 	// Sync read
 	do.trMutex.RLock()
 	defer do.trMutex.RUnlock()
 
 	if do.translations != nil {
 		if _, ok := do.translations[str]; ok {
-			return FormatString(do.translations[str].GetN(do.pluralForm(n)), vars...)
+			return FormatString(do.translations[str].GetN(pluralForm), vars...)
 		}
 	}
 
 	// Parse plural forms to distinguish between plural and singular
-	if do.pluralForm(n) == 0 {
+	if pluralForm == 0 {
 		return FormatString(str, vars...)
 	}
 	return FormatString(plural, vars...)
@@ -344,18 +447,22 @@ func (do *Domain) GetN(str, plural string, n int, vars ...any) string {
 // AppendN adds the (N)th plural form of Translation for the given string.
 // Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
 func (do *Domain) AppendN(b []byte, str, plural string, n int, vars ...any) []byte {
+	// Get plural form before acquiring the translation lock so a custom
+	// resolver is never called while a project lock is held.
+	pluralForm := do.pluralForm(n)
+
 	// Sync read
 	do.trMutex.RLock()
 	defer do.trMutex.RUnlock()
 
 	if do.translations != nil {
 		if _, ok := do.translations[str]; ok {
-			return Appendf(b, do.translations[str].GetN(do.pluralForm(n)), vars...)
+			return Appendf(b, do.translations[str].GetN(pluralForm), vars...)
 		}
 	}
 
 	// Parse plural forms to distinguish between plural and singular
-	if do.pluralForm(n) == 0 {
+	if pluralForm == 0 {
 		return Appendf(b, str, vars...)
 	}
 	return Appendf(b, plural, vars...)
@@ -459,17 +566,20 @@ func (do *Domain) SetNC(id, plural, ctx string, n int, str string) {
 // GetNC retrieves the (N)th plural form of Translation for the given string in the given context.
 // Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
 func (do *Domain) GetNC(str, plural string, n int, ctx string, vars ...any) string {
-	do.trMutex.RLock()
-	defer do.trMutex.RUnlock()
+	if do.hasContextTranslation(str, ctx) {
+		// Get plural form before acquiring the translation lock so a custom
+		// resolver is never called while a project lock is held.
+		pluralForm := do.pluralForm(n)
 
-	if do.contextTranslations != nil {
-		if _, ok := do.contextTranslations[ctx]; ok {
-			if do.contextTranslations[ctx] != nil {
-				if _, ok := do.contextTranslations[ctx][str]; ok {
-					return FormatString(do.contextTranslations[ctx][str].GetN(do.pluralForm(n)), vars...)
-				}
+		do.trMutex.RLock()
+		if translations, ok := do.contextTranslations[ctx]; ok && translations != nil {
+			if trans, ok := translations[str]; ok && trans != nil {
+				translated := trans.GetN(pluralForm)
+				do.trMutex.RUnlock()
+				return FormatString(translated, vars...)
 			}
 		}
+		do.trMutex.RUnlock()
 	}
 
 	if n == 1 {
@@ -481,17 +591,20 @@ func (do *Domain) GetNC(str, plural string, n int, ctx string, vars ...any) stri
 // AppendNC retrieves the (N)th plural form of Translation for the given string in the given context.
 // Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
 func (do *Domain) AppendNC(b []byte, str, plural string, n int, ctx string, vars ...any) []byte {
-	do.trMutex.RLock()
-	defer do.trMutex.RUnlock()
+	if do.hasContextTranslation(str, ctx) {
+		// Get plural form before acquiring the translation lock so a custom
+		// resolver is never called while a project lock is held.
+		pluralForm := do.pluralForm(n)
 
-	if do.contextTranslations != nil {
-		if _, ok := do.contextTranslations[ctx]; ok {
-			if do.contextTranslations[ctx] != nil {
-				if _, ok := do.contextTranslations[ctx][str]; ok {
-					return Appendf(b, do.contextTranslations[ctx][str].GetN(do.pluralForm(n)), vars...)
-				}
+		do.trMutex.RLock()
+		if translations, ok := do.contextTranslations[ctx]; ok && translations != nil {
+			if trans, ok := translations[str]; ok && trans != nil {
+				translated := trans.GetN(pluralForm)
+				do.trMutex.RUnlock()
+				return Appendf(b, translated, vars...)
 			}
 		}
+		do.trMutex.RUnlock()
 	}
 
 	if n == 1 {
@@ -507,6 +620,14 @@ func (do *Domain) IsTranslated(str string) bool {
 
 // IsTranslatedN reports whether a plural string is translated
 func (do *Domain) IsTranslatedN(str string, n int) bool {
+	if !do.hasTranslation(str) {
+		return false
+	}
+
+	// Get plural form before acquiring the translation lock so a custom
+	// resolver is never called while a project lock is held.
+	pluralForm := do.pluralForm(n)
+
 	do.trMutex.RLock()
 	defer do.trMutex.RUnlock()
 
@@ -514,10 +635,10 @@ func (do *Domain) IsTranslatedN(str string, n int) bool {
 		return false
 	}
 	tr, ok := do.translations[str]
-	if !ok {
+	if !ok || tr == nil {
 		return false
 	}
-	return tr.IsTranslatedN(do.pluralForm(n))
+	return tr.IsTranslatedN(pluralForm)
 }
 
 // IsTranslatedC reports whether a context string is translated
@@ -527,6 +648,14 @@ func (do *Domain) IsTranslatedC(str, ctx string) bool {
 
 // IsTranslatedNC reports whether a plural context string is translated
 func (do *Domain) IsTranslatedNC(str string, n int, ctx string) bool {
+	if !do.hasContextTranslation(str, ctx) {
+		return false
+	}
+
+	// Get plural form before acquiring the translation lock so a custom
+	// resolver is never called while a project lock is held.
+	pluralForm := do.pluralForm(n)
+
 	do.trMutex.RLock()
 	defer do.trMutex.RUnlock()
 
@@ -534,36 +663,24 @@ func (do *Domain) IsTranslatedNC(str string, n int, ctx string) bool {
 		return false
 	}
 	translations, ok := do.contextTranslations[ctx]
-	if !ok {
+	if !ok || translations == nil {
 		return false
 	}
 	tr, ok := translations[str]
-	if !ok {
+	if !ok || tr == nil {
 		return false
 	}
-	return tr.IsTranslatedN(do.pluralForm(n))
+	return tr.IsTranslatedN(pluralForm)
 }
 
 // GetTranslations returns a copy of every translation in the domain. It does not support contexts.
 func (do *Domain) GetTranslations() map[string]*Translation {
-	all := make(map[string]*Translation, len(do.translations))
-
 	do.trMutex.RLock()
 	defer do.trMutex.RUnlock()
 
+	all := make(map[string]*Translation, len(do.translations))
 	for msgID, trans := range do.translations {
-		newTrans := NewTranslation()
-		newTrans.ID = trans.ID
-		newTrans.PluralID = trans.PluralID
-		newTrans.dirty = trans.dirty
-		if len(trans.Refs) > 0 {
-			newTrans.Refs = make([]string, len(trans.Refs))
-			copy(newTrans.Refs, trans.Refs)
-		}
-		for k, v := range trans.Trs {
-			newTrans.Trs[k] = v
-		}
-		all[msgID] = newTrans
+		all[msgID] = cloneTranslation(trans)
 	}
 
 	return all
@@ -571,32 +688,18 @@ func (do *Domain) GetTranslations() map[string]*Translation {
 
 // GetCtxTranslations returns a copy of every translation in the domain with context
 func (do *Domain) GetCtxTranslations() map[string]map[string]*Translation {
-	all := make(map[string]map[string]*Translation, len(do.contextTranslations))
-
 	do.trMutex.RLock()
 	defer do.trMutex.RUnlock()
 
+	all := make(map[string]map[string]*Translation, len(do.contextTranslations))
 	for ctx, translations := range do.contextTranslations {
 		for msgID, trans := range translations {
-			newTrans := NewTranslation()
-			newTrans.ID = trans.ID
-			newTrans.PluralID = trans.PluralID
-			newTrans.dirty = trans.dirty
-			if len(trans.Refs) > 0 {
-				newTrans.Refs = make([]string, len(trans.Refs))
-				copy(newTrans.Refs, trans.Refs)
-			}
-			for k, v := range trans.Trs {
-				newTrans.Trs[k] = v
-			}
-
 			if all[ctx] == nil {
 				all[ctx] = make(map[string]*Translation)
 			}
 
-			all[ctx][msgID] = newTrans
+			all[ctx][msgID] = cloneTranslation(trans)
 		}
-
 	}
 
 	return all
@@ -627,6 +730,11 @@ func extractPathAndLine(ref string) (string, int) {
 // MarshalText implements encoding.TextMarshaler interface
 // Assists round-trip of POT/PO content
 func (do *Domain) MarshalText() ([]byte, error) {
+	do.trMutex.RLock()
+	do.pluralMutex.RLock()
+	defer do.trMutex.RUnlock()
+	defer do.pluralMutex.RUnlock()
+
 	var buf bytes.Buffer
 	if len(do.headerComments) > 0 {
 		buf.WriteString(strings.Join(do.headerComments, "\n"))
@@ -774,9 +882,16 @@ func (do *Domain) MarshalText() ([]byte, error) {
 		if trans.PluralID == "" {
 			buf.WriteString("\nmsgstr \"" + EscapeSpecialCharacters(trans.Trs[0]) + "\"")
 		} else {
-			buf.WriteString("\nmsgid_plural \"" + trans.PluralID + "\"")
-			for i, tr := range trans.Trs {
-				buf.WriteString("\nmsgstr[" + EscapeSpecialCharacters(strconv.Itoa(i)) + "] \"" + tr + "\"")
+			buf.WriteString("\nmsgid_plural \"" + EscapeSpecialCharacters(trans.PluralID) + "\"")
+
+			pluralIndexes := make([]int, 0, len(trans.Trs))
+			for i := range trans.Trs {
+				pluralIndexes = append(pluralIndexes, i)
+			}
+			sort.Ints(pluralIndexes)
+
+			for _, i := range pluralIndexes {
+				buf.WriteString("\nmsgstr[" + strconv.Itoa(i) + "] \"" + EscapeSpecialCharacters(trans.Trs[i]) + "\"")
 			}
 		}
 	}
@@ -786,8 +901,28 @@ func (do *Domain) MarshalText() ([]byte, error) {
 
 // EscapeSpecialCharacters escapes special characters in a string
 func EscapeSpecialCharacters(s string) string {
-	s = regexp.MustCompile(`([^\\])(")`).ReplaceAllString(s, "$1\\\"") // Escape non-escaped double quotation marks
+	var escaped strings.Builder
+	escaped.Grow(len(s))
 
+	for i := range s {
+		switch s[i] {
+		case '\\':
+			escaped.WriteByte('\\')
+			// Preserve already-escaped quote sequences for compatibility.
+			if i+1 >= len(s) || s[i+1] != '"' {
+				escaped.WriteByte('\\')
+			}
+		case '"':
+			if i == 0 || s[i-1] != '\\' {
+				escaped.WriteByte('\\')
+			}
+			escaped.WriteByte('"')
+		default:
+			escaped.WriteByte(s[i])
+		}
+	}
+
+	s = escaped.String()
 	if strings.Count(s, "\n") == 0 {
 		return s
 	}
@@ -821,16 +956,26 @@ func EscapeSpecialCharacters(s string) string {
 	return strings.Join(data, "\n")
 }
 
+func (do *Domain) translatorEncodingSnapshot() *TranslatorEncoding {
+	do.trMutex.RLock()
+	do.pluralMutex.RLock()
+	defer do.trMutex.RUnlock()
+	defer do.pluralMutex.RUnlock()
+
+	return &TranslatorEncoding{
+		Headers:      cloneHeaderMap(do.Headers),
+		Language:     do.Language,
+		PluralForms:  do.PluralForms,
+		Nplurals:     do.nplurals,
+		Plural:       do.plural,
+		Translations: cloneTranslations(do.translations),
+		Contexts:     cloneContextTranslations(do.contextTranslations),
+	}
+}
+
 // MarshalBinary implements encoding.BinaryMarshaler interface
 func (do *Domain) MarshalBinary() ([]byte, error) {
-	obj := new(TranslatorEncoding)
-	obj.Headers = do.Headers
-	obj.Language = do.Language
-	obj.PluralForms = do.PluralForms
-	obj.Nplurals = do.nplurals
-	obj.Plural = do.plural
-	obj.Translations = do.translations
-	obj.Contexts = do.contextTranslations
+	obj := do.translatorEncodingSnapshot()
 
 	var buff bytes.Buffer
 	encoder := gob.NewEncoder(&buff)
@@ -845,22 +990,68 @@ func (do *Domain) UnmarshalBinary(data []byte) error {
 	obj := new(TranslatorEncoding)
 
 	decoder := gob.NewDecoder(buff)
-	err := decoder.Decode(obj)
-	if err != nil {
+	if err := decoder.Decode(obj); err != nil {
 		return err
 	}
 
-	do.Headers = obj.Headers
+	headers := cloneHeaderMap(obj.Headers)
+	if headers == nil {
+		headers = make(HeaderMap)
+	}
+	translations := cloneTranslations(obj.Translations)
+	if translations == nil {
+		translations = make(map[string]*Translation)
+	}
+	contextTranslations := cloneContextTranslations(obj.Contexts)
+	if contextTranslations == nil {
+		contextTranslations = make(map[string]map[string]*Translation)
+	}
+
+	for id, trans := range translations {
+		if trans == nil {
+			trans = NewTranslation()
+			trans.ID = id
+			translations[id] = trans
+		}
+	}
+	for context, translationsForContext := range contextTranslations {
+		if translationsForContext == nil {
+			contextTranslations[context] = make(map[string]*Translation)
+			continue
+		}
+		for id, trans := range translationsForContext {
+			if trans == nil {
+				trans = NewTranslation()
+				trans.ID = id
+				translationsForContext[id] = trans
+			}
+		}
+	}
+
+	var pluralforms plurals.Expression
+	if expr, err := plurals.Compile(obj.Plural); err == nil {
+		pluralforms = expr
+	}
+
+	do.trMutex.Lock()
+	do.pluralMutex.Lock()
+
+	do.Headers = headers
 	do.Language = obj.Language
 	do.PluralForms = obj.PluralForms
 	do.nplurals = obj.Nplurals
 	do.plural = obj.Plural
-	do.translations = obj.Translations
-	do.contextTranslations = obj.Contexts
+	do.pluralforms = pluralforms
+	do.translations = translations
+	do.contextTranslations = contextTranslations
+	do.pluralTranslations = make(map[string]*Translation)
+	do.headerComments = make([]string, 0)
+	do.trBuffer = nil
+	do.ctxBuffer = ""
+	do.refBuffer = ""
 
-	if expr, err := plurals.Compile(do.plural); err == nil {
-		do.pluralforms = expr
-	}
+	do.pluralMutex.Unlock()
+	do.trMutex.Unlock()
 
 	return nil
 }

--- a/domain_test.go
+++ b/domain_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 const (
@@ -13,34 +14,42 @@ const (
 	arFixture   = "fixtures/ar/categories.po"
 )
 
+func encodeTestGob(t testing.TB, value any) []byte {
+	t.Helper()
+
+	var encoded bytes.Buffer
+	if err := gob.NewEncoder(&encoded).Encode(value); err != nil {
+		t.Fatalf("encode test gob: %v", err)
+	}
+	return encoded.Bytes()
+}
+
 // since both Po and Mo just pass-through to Domain for MarshalBinary and UnmarshalBinary, test it here
 func TestBinaryEncoding(t *testing.T) {
-	// Create po objects
+	data := encodeTestGob(t, &TranslatorEncoding{
+		Language: "en_US",
+		Translations: map[string]*Translation{
+			"My text": {
+				ID:  "My text",
+				Trs: map[int]string{0: "Translated text"},
+			},
+			"language": {
+				ID:  "language",
+				Trs: map[int]string{0: "en_US"},
+			},
+		},
+	})
+
 	po := NewPo()
-	po2 := NewPo()
-
-	// Parse file
-	po.ParseFile(enUSFixture)
-
-	buff, err := po.GetDomain().MarshalBinary()
-	if err != nil {
+	if err := po.UnmarshalBinary(data); err != nil {
 		t.Fatal(err)
 	}
 
-	err = po2.GetDomain().UnmarshalBinary(buff)
-	if err != nil {
-		t.Fatal(err)
+	if got := po.Get("My text"); got != "Translated text" {
+		t.Errorf("decoded My text = %q, want %q", got, "Translated text")
 	}
-
-	// Test translations
-	tr := po2.Get("My text")
-	if tr != translatedText {
-		t.Errorf("Expected '%s' but got '%s'", translatedText, tr)
-	}
-	// Test translations
-	tr = po2.Get("language")
-	if tr != "en_US" {
-		t.Errorf("Expected 'en_US' but got '%s'", tr)
+	if got := po.Get("language"); got != "en_US" {
+		t.Errorf("decoded language = %q, want %q", got, "en_US")
 	}
 }
 
@@ -348,11 +357,14 @@ func TestDomain_Refs(t *testing.T) {
 
 func TestDomain_HeaderMap(t *testing.T) {
 	d := NewDomain()
-	d.Headers.Del("Missing") // No-op but increases coverage
 
 	d.Headers.Set("Key", "Value")
 	if d.Headers.Get("Key") != "Value" {
 		t.Error("Header Get/Set failed")
+	}
+	d.Headers.Del("Missing")
+	if got := d.Headers.Get("Key"); got != "Value" {
+		t.Errorf("Del missing header changed Key: got %q, want Value", got)
 	}
 
 	d.Headers.Add("Key", "Value2")
@@ -400,7 +412,18 @@ func TestDomain_CustomPluralResolverCanReenter(t *testing.T) {
 		return 0
 	})
 
-	d.SetN("message", "messages", 2, "message")
+	done := make(chan struct{}, 1)
+	go func() {
+		d.SetN("message", "messages", 2, "message")
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("custom plural resolver deadlocked while reentering Domain")
+	}
+
 	if got := d.Get("reentrant"); got != "value" {
 		t.Fatalf("reentrant resolver mutation produced %q, want %q", got, "value")
 	}
@@ -434,28 +457,14 @@ func TestDomain_MarshalPluralEscapingAndOrder(t *testing.T) {
 		previous = position
 	}
 
-	parsed := NewPo()
-	parsed.Parse(data)
-	parsedTranslation, ok := parsed.GetDomain().GetTranslations()[trans.ID]
-	if !ok {
-		t.Fatalf("parsed translation %q was not found", trans.ID)
-	}
-
-	expectedPluralID := strings.ReplaceAll(trans.PluralID, `\"`, `"`)
-	if parsedTranslation.PluralID != expectedPluralID {
-		t.Errorf("plural ID did not round-trip: got %q, want %q", parsedTranslation.PluralID, expectedPluralID)
-	}
-	expectedTranslations := map[int]string{
-		0: trans.Trs[0],
-		1: strings.ReplaceAll(trans.Trs[1], `\"`, `"`),
-		2: trans.Trs[2],
-	}
-	if len(parsedTranslation.Trs) != len(expectedTranslations) {
-		t.Fatalf("plural translations were not retained: got %d, want %d", len(parsedTranslation.Trs), len(expectedTranslations))
-	}
-	for index, want := range expectedTranslations {
-		if got := parsedTranslation.Trs[index]; got != want {
-			t.Errorf("plural translation %d did not round-trip: got %q, want %q", index, got, want)
+	for _, fragment := range []string{
+		`msgid "\"leading\" and embedded \"quote\" \\raw"`,
+		`"embedded \"quote\" and \"preserved with \\raw"`,
+		`msgstr[1] "already \"escaped"`,
+		`"with \"quote\" and \\raw`,
+	} {
+		if !strings.Contains(output, fragment) {
+			t.Errorf("MarshalText output missing escaped fragment %q:\n%s", fragment, output)
 		}
 	}
 }

--- a/domain_test.go
+++ b/domain_test.go
@@ -1,6 +1,10 @@
 package gotext
 
 import (
+	"bytes"
+	"encoding/gob"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -110,6 +114,34 @@ func TestDomain_GetCtxTranslations(t *testing.T) {
 			}
 		}
 
+	}
+}
+
+func TestDomain_TranslationCopiesOwnPluralMap(t *testing.T) {
+	d := NewDomain()
+
+	translation := NewTranslation()
+	translation.ID = "id"
+	translation.Trs[2] = "plural"
+	d.translations[translation.ID] = translation
+
+	contextTranslation := NewTranslation()
+	contextTranslation.ID = "contextual id"
+	contextTranslation.Trs[1] = "contextual plural"
+	d.contextTranslations["context"] = map[string]*Translation{
+		contextTranslation.ID: contextTranslation,
+	}
+
+	copied := d.GetTranslations()[translation.ID]
+	copied.Trs[2] = "changed"
+	if got := d.translations[translation.ID].Trs[2]; got != "plural" {
+		t.Fatalf("GetTranslations should own its Trs map, got %q in source", got)
+	}
+
+	copiedContext := d.GetCtxTranslations()["context"][contextTranslation.ID]
+	copiedContext.Trs[1] = "changed"
+	if got := d.contextTranslations["context"][contextTranslation.ID].Trs[1]; got != "contextual plural" {
+		t.Fatalf("GetCtxTranslations should own its Trs map, got %q in source", got)
 	}
 }
 
@@ -351,4 +383,306 @@ func TestDomain_SetPluralResolver(t *testing.T) {
 	if d.pluralForm(10) != 5 {
 		t.Error("Custom plural resolver failed")
 	}
+
+	po := NewPo()
+	po.SetPluralResolver(func(n int) int {
+		return 6
+	})
+	if got := po.GetDomain().pluralForm(10); got != 6 {
+		t.Errorf("Po custom plural resolver = %d, want 6", got)
+	}
+}
+
+func TestDomain_CustomPluralResolverCanReenter(t *testing.T) {
+	d := NewDomain()
+	d.SetPluralResolver(func(int) int {
+		d.Set("reentrant", "value")
+		return 0
+	})
+
+	d.SetN("message", "messages", 2, "message")
+	if got := d.Get("reentrant"); got != "value" {
+		t.Fatalf("reentrant resolver mutation produced %q, want %q", got, "value")
+	}
+}
+
+func TestDomain_MarshalPluralEscapingAndOrder(t *testing.T) {
+	d := NewDomain()
+	trans := NewTranslation()
+	trans.ID = "\"leading\" and embedded \"quote\" \\raw"
+	trans.PluralID = "\"plural leading\nembedded \"quote\" and \\\"preserved with \\raw"
+	trans.Trs[2] = "line two\nwith \"quote\" and \\raw"
+	trans.Trs[0] = "\"translation leading\nwith \\raw"
+	trans.Trs[1] = `already \"escaped`
+	d.translations[trans.ID] = trans
+
+	data, err := d.MarshalText()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output := string(data)
+	previous := strings.Index(output, "msgid_plural")
+	if previous == -1 {
+		t.Fatal("expected a plural message")
+	}
+	for _, marker := range []string{"msgstr[0]", "msgstr[1]", "msgstr[2]"} {
+		position := strings.Index(output, marker)
+		if position <= previous {
+			t.Fatalf("expected %s after the preceding plural field in %q", marker, output)
+		}
+		previous = position
+	}
+
+	parsed := NewPo()
+	parsed.Parse(data)
+	parsedTranslation, ok := parsed.GetDomain().GetTranslations()[trans.ID]
+	if !ok {
+		t.Fatalf("parsed translation %q was not found", trans.ID)
+	}
+
+	expectedPluralID := strings.ReplaceAll(trans.PluralID, `\"`, `"`)
+	if parsedTranslation.PluralID != expectedPluralID {
+		t.Errorf("plural ID did not round-trip: got %q, want %q", parsedTranslation.PluralID, expectedPluralID)
+	}
+	expectedTranslations := map[int]string{
+		0: trans.Trs[0],
+		1: strings.ReplaceAll(trans.Trs[1], `\"`, `"`),
+		2: trans.Trs[2],
+	}
+	if len(parsedTranslation.Trs) != len(expectedTranslations) {
+		t.Fatalf("plural translations were not retained: got %d, want %d", len(parsedTranslation.Trs), len(expectedTranslations))
+	}
+	for index, want := range expectedTranslations {
+		if got := parsedTranslation.Trs[index]; got != want {
+			t.Errorf("plural translation %d did not round-trip: got %q, want %q", index, got, want)
+		}
+	}
+}
+
+func TestDomain_ParseHeadersUsesSplitSeqAndCut(t *testing.T) {
+	d := NewDomain()
+	header := NewTranslation()
+	header.Trs[0] = "\n\nlanguage: en_US:UTF-8\nLANGUAGE: en_GB\nX-Custom: value=with=equals\nX-Custom: duplicate\npLuRaL-fOrMs: nplurals=3; malformed; plural=n != 1; ignored=a=b\n"
+	d.translations[""] = header
+
+	d.parseHeaders()
+
+	if got := d.Language; got != "en_GB" {
+		t.Errorf("Language = %q, want %q", got, "en_GB")
+	}
+	if got := d.Headers.Get("language"); got != "en_US:UTF-8" {
+		t.Errorf("lower-case Language header = %q, want %q", got, "en_US:UTF-8")
+	}
+	if got := d.Headers.Get("LANGUAGE"); got != "en_GB" {
+		t.Errorf("upper-case Language header = %q, want %q", got, "en_GB")
+	}
+	customValues := d.Headers.Values("X-Custom")
+	if len(customValues) != 2 || customValues[0] != "value=with=equals" || customValues[1] != "duplicate" {
+		t.Errorf("duplicate custom headers = %v", customValues)
+	}
+
+	wantPluralForms := "nplurals=3; malformed; plural=n != 1; ignored=a=b"
+	if d.PluralForms != wantPluralForms {
+		t.Errorf("PluralForms = %q, want %q", d.PluralForms, wantPluralForms)
+	}
+	if d.nplurals != 3 {
+		t.Errorf("nplurals = %d, want 3", d.nplurals)
+	}
+	if d.plural != "n != 1" {
+		t.Errorf("plural expression = %q, want %q", d.plural, "n != 1")
+	}
+	if got := d.pluralForm(1); got != 0 {
+		t.Errorf("plural form for one = %d, want 0", got)
+	}
+	if got := d.pluralForm(2); got != 1 {
+		t.Errorf("plural form for two = %d, want 1", got)
+	}
+}
+
+func TestDomain_SetRefsOwnsSliceAndRefreshesExisting(t *testing.T) {
+	d := NewDomain()
+	trans := NewTranslation()
+	trans.ID = "message"
+	d.translations[trans.ID] = trans
+
+	refs := []string{"file.go:1"}
+	d.SetRefs(trans.ID, refs)
+	refs[0] = "file.go:2"
+
+	if got := d.GetRefs(trans.ID); len(got) != 1 || got[0] != "file.go:1" {
+		t.Fatalf("SetRefs should own its input, got %v", got)
+	}
+	if trans.IsStale() {
+		t.Fatal("SetRefs should mark an existing translation dirty")
+	}
+	d.DropStaleTranslations()
+	if _, ok := d.translations[trans.ID]; !ok {
+		t.Fatal("DropStaleTranslations removed a translation refreshed by SetRefs")
+	}
+
+	got := d.GetRefs(trans.ID)
+	got[0] = "file.go:3"
+	if got = d.GetRefs(trans.ID); got[0] != "file.go:1" {
+		t.Fatalf("GetRefs should return an independent slice, got %v", got)
+	}
+}
+
+func TestDomain_BinarySnapshotAndInvalidDecodeAreSafe(t *testing.T) {
+	d := NewDomain()
+	d.Headers.Set("X-Test", "before")
+	d.Set("message", "before")
+	d.SetRefs("message", []string{"file.go:1"})
+
+	data, err := d.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d.Headers.Set("X-Test", "after")
+	d.Set("message", "after")
+
+	restored := NewDomain()
+	if err := restored.UnmarshalBinary(data); err != nil {
+		t.Fatal(err)
+	}
+	if got := restored.Get("message"); got != "before" {
+		t.Fatalf("binary snapshot message = %q, want %q", got, "before")
+	}
+	if got := restored.Headers.Get("X-Test"); got != "before" {
+		t.Fatalf("binary snapshot header = %q, want %q", got, "before")
+	}
+	if got := restored.GetRefs("message"); len(got) != 1 || got[0] != "file.go:1" {
+		t.Fatalf("binary snapshot refs = %v", got)
+	}
+
+	if err := d.UnmarshalBinary([]byte("not gob")); err == nil {
+		t.Fatal("invalid binary should return an error")
+	}
+	if got := d.Get("message"); got != "after" {
+		t.Fatalf("invalid decode changed translation to %q", got)
+	}
+	if got := d.Headers.Get("X-Test"); got != "after" {
+		t.Fatalf("invalid decode changed header to %q", got)
+	}
+}
+
+func TestDomain_UnmarshalBinaryInvalidPluralUsesFallback(t *testing.T) {
+	var encoded bytes.Buffer
+	if err := gob.NewEncoder(&encoded).Encode(&TranslatorEncoding{
+		Plural: "n +",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	d := NewDomain()
+	d.SetPluralResolver(func(int) int {
+		return 7
+	})
+	if err := d.UnmarshalBinary(encoded.Bytes()); err != nil {
+		t.Fatal(err)
+	}
+	if got := d.pluralForm(2); got != 7 {
+		t.Fatalf("invalid plural should use custom fallback, got %d", got)
+	}
+
+	d.SetPluralResolver(nil)
+	if got := d.pluralForm(1); got != 0 {
+		t.Fatalf("invalid plural singular fallback = %d, want 0", got)
+	}
+	if got := d.pluralForm(2); got != 1 {
+		t.Fatalf("invalid plural plural fallback = %d, want 1", got)
+	}
+}
+
+func TestDomainConcurrentSupportedAccess(t *testing.T) {
+	d := NewDomain()
+	d.Set("message", "initial")
+	d.SetC("message", "context", "initial context")
+	d.SetRefs("message", []string{"file.go:1"})
+	seed, err := d.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const iterations = 128
+	var wg sync.WaitGroup
+	wg.Add(8)
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			d.Set("message", "value")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			d.SetC("message", "context", "context value")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			d.SetN("message", "messages", i, "plural value")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			d.SetRefs("message", []string{"file.go:1", "file.go:2"})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			if i%2 == 0 {
+				d.SetPluralResolver(func(int) int { return 0 })
+			} else {
+				d.SetPluralResolver(func(int) int { return 1 })
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			refs := d.GetRefs("message")
+			if len(refs) > 0 {
+				refs[0] = "caller mutation"
+			}
+			for _, trans := range d.GetTranslations() {
+				if trans != nil {
+					trans.Trs[0] = "caller mutation"
+				}
+			}
+			for _, translations := range d.GetCtxTranslations() {
+				for _, trans := range translations {
+					if trans != nil {
+						trans.Trs[0] = "caller mutation"
+					}
+				}
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			if _, err := d.MarshalText(); err != nil {
+				t.Errorf("MarshalText: %v", err)
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			if _, err := d.MarshalBinary(); err != nil {
+				t.Errorf("MarshalBinary: %v", err)
+			}
+			if err := d.UnmarshalBinary(seed); err != nil {
+				t.Errorf("UnmarshalBinary: %v", err)
+			}
+		}
+	}()
+
+	wg.Wait()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/leonelquinteros/gotext
 
-require golang.org/x/tools v0.31.0
+require golang.org/x/tools v0.49.0
 
 require (
-	golang.org/x/mod v0.24.0 // indirect
-	golang.org/x/sync v0.12.0 // indirect
+	golang.org/x/mod v0.39.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 )
 
-go 1.25
+go 1.27

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
-golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
-golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
-golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
-golang.org/x/tools v0.31.0 h1:0EedkvKDbh+qistFTd0Bcwe/YLh4vHwWEkiI0toFIBU=
-golang.org/x/tools v0.31.0/go.mod h1:naFTU+Cev749tSJRXJlna0T3WxKvb1kWEx15xA4SdmQ=
+golang.org/x/mod v0.39.0 h1:UF5zwQdCRRUpHfyPwr7d4UrGiVeldIsogtzWVnczL74=
+golang.org/x/mod v0.39.0/go.mod h1:bvIbwjQ0HUFFf5AKukeeYQG4ZBUG9yxQbR9aEweIwYY=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.49.0 h1:3NI7VXzL9+1WZD52Dx2ttoPwD5DWrFGpl9mFZDlmisI=
+golang.org/x/tools v0.49.0/go.mod h1:SJNXV9DBKT0UbdttsQjbfJlAE/q+y36++zo3uL3N0Oo=

--- a/gotext.go
+++ b/gotext.go
@@ -69,37 +69,47 @@ func loadLocales(rebuildCache bool) {
 	globalConfig.Lock()
 
 	if globalConfig.locales == nil || rebuildCache {
-		var locales []*Locale
+		locales := make([]*Locale, 0, len(globalConfig.languages))
 		for _, language := range globalConfig.languages {
 			locales = append(locales, NewLocale(globalConfig.library, language))
 		}
 		globalConfig.locales = locales
 	}
 
-	for _, locale := range globalConfig.locales {
-		if _, ok := locale.Domains[globalConfig.domain]; !ok || rebuildCache {
-			locale.AddDomain(globalConfig.domain)
-		}
-		locale.SetDomain(globalConfig.domain)
-	}
-
+	locales := append([]*Locale(nil), globalConfig.locales...)
+	domain := globalConfig.domain
 	globalConfig.Unlock()
+
+	for _, locale := range locales {
+		if locale == nil {
+			continue
+		}
+		if rebuildCache || !locale.hasDomain(domain) {
+			locale.AddDomain(domain)
+		}
+		locale.SetDomain(domain)
+	}
 }
 
 // GetDomain is the domain getter for the package configuration
 func GetDomain() string {
-	var dom string
 	globalConfig.RLock()
-	if globalConfig.locales != nil {
-		// All locales have the same domain
-		dom = globalConfig.locales[0].GetDomain()
-	}
-	if dom == "" {
-		dom = globalConfig.domain
+	domain := globalConfig.domain
+	var locale *Locale
+	for _, candidate := range globalConfig.locales {
+		if candidate != nil {
+			locale = candidate
+			break
+		}
 	}
 	globalConfig.RUnlock()
 
-	return dom
+	if locale != nil {
+		if localeDomain := locale.GetDomain(); localeDomain != "" {
+			return localeDomain
+		}
+	}
+	return domain
 }
 
 // SetDomain sets the name for the domain to be used at package level.
@@ -107,8 +117,8 @@ func GetDomain() string {
 func SetDomain(dom string) {
 	globalConfig.Lock()
 	globalConfig.domain = dom
-	if globalConfig.locales != nil {
-		for _, locale := range globalConfig.locales {
+	for _, locale := range globalConfig.locales {
+		if locale != nil {
 			locale.SetDomain(dom)
 		}
 	}
@@ -131,8 +141,10 @@ func GetLanguage() string {
 // GetLanguages returns all languages that have been supplied.
 func GetLanguages() []string {
 	globalConfig.RLock()
-	defer globalConfig.RUnlock()
-	return globalConfig.languages
+	languages := make([]string, len(globalConfig.languages))
+	copy(languages, globalConfig.languages)
+	globalConfig.RUnlock()
+	return languages
 }
 
 // SetLanguage sets the language code (or colon separated language codes) to be used at package level.
@@ -171,17 +183,20 @@ func SetLibrary(lib string) {
 // GetLocales returns the locales that have been set for the package configuration.
 func GetLocales() []*Locale {
 	globalConfig.RLock()
-	defer globalConfig.RUnlock()
-	return globalConfig.locales
+	locales := make([]*Locale, len(globalConfig.locales))
+	copy(locales, globalConfig.locales)
+	globalConfig.RUnlock()
+	return locales
 }
 
 // GetStorage is the locale storage getter for the package configuration.
 //
 // Deprecated: Storage has been renamed to Locale for consistency, use GetLocales instead.
 func GetStorage() *Locale {
-	locales := GetLocales()
-	if len(locales) > 0 {
-		return locales[0]
+	for _, locale := range GetLocales() {
+		if locale != nil {
+			return locale
+		}
 	}
 	return nil
 }
@@ -190,24 +205,40 @@ func GetStorage() *Locale {
 // NewLocale(). This makes it possible to attach custom Domain objects from in-memory po/mo.
 // The library, language and domain of the first Locale will set the default global configuration.
 func SetLocales(locales []*Locale) {
+	ownedLocales := make([]*Locale, len(locales))
+	copy(ownedLocales, locales)
+
 	globalConfig.Lock()
-	defer globalConfig.Unlock()
+	globalConfig.locales = ownedLocales
 
-	globalConfig.locales = locales
-	globalConfig.library = locales[0].path
-	globalConfig.domain = locales[0].defaultDomain
+	languages := make([]string, 0, len(ownedLocales))
+	var first *Locale
+	for _, locale := range ownedLocales {
+		if locale == nil {
+			continue
+		}
 
-	var languages []string
-	for _, locale := range locales {
+		locale.RLock()
+		if first == nil {
+			first = locale
+			globalConfig.library = locale.path
+			globalConfig.domain = locale.defaultDomain
+		}
 		languages = append(languages, locale.lang)
+		locale.RUnlock()
 	}
 	globalConfig.languages = languages
+	globalConfig.Unlock()
 }
 
 // SetStorage allows overriding the global Locale object with one built manually with NewLocale().
 //
 // Deprecated: Storage has been renamed to Locale for consistency, use SetLocales instead.
 func SetStorage(locale *Locale) {
+	if locale == nil {
+		SetLocales(nil)
+		return
+	}
 	SetLocales([]*Locale{locale})
 }
 
@@ -247,21 +278,24 @@ func GetD(dom, str string, vars ...any) string {
 	// Try to load default package Locales
 	loadLocales(false)
 
-	globalConfig.RLock()
-	defer globalConfig.RUnlock()
-
-	var tr string
-	for i, locale := range globalConfig.locales {
-		if _, ok := locale.Domains[dom]; !ok {
-			locale.AddDomain(dom)
-		}
-		if !locale.IsTranslatedD(dom, str) && i < (len(globalConfig.locales)-1) {
+	locales := GetLocales()
+	var fallback *Locale
+	for _, locale := range locales {
+		if locale == nil {
 			continue
 		}
-		tr = locale.GetD(dom, str, vars...)
-		break
+		fallback = locale
+		if !locale.hasDomain(dom) {
+			locale.AddDomain(dom)
+		}
+		if locale.IsTranslatedD(dom, str) {
+			return locale.GetD(dom, str, vars...)
+		}
 	}
-	return tr
+	if fallback != nil {
+		return fallback.GetD(dom, str, vars...)
+	}
+	return FormatString(str, vars...)
 }
 
 // GetND retrieves the (N)th plural form of Translation in the given domain for a given string.
@@ -270,21 +304,27 @@ func GetND(dom, str, plural string, n int, vars ...any) string {
 	// Try to load default package Locales
 	loadLocales(false)
 
-	globalConfig.RLock()
-	defer globalConfig.RUnlock()
-
-	var tr string
-	for i, locale := range globalConfig.locales {
-		if _, ok := locale.Domains[dom]; !ok {
-			locale.AddDomain(dom)
-		}
-		if !locale.IsTranslatedND(dom, str, n) && i < (len(globalConfig.locales)-1) {
+	locales := GetLocales()
+	var fallback *Locale
+	for _, locale := range locales {
+		if locale == nil {
 			continue
 		}
-		tr = locale.GetND(dom, str, plural, n, vars...)
-		break
+		fallback = locale
+		if !locale.hasDomain(dom) {
+			locale.AddDomain(dom)
+		}
+		if locale.IsTranslatedND(dom, str, n) {
+			return locale.GetND(dom, str, plural, n, vars...)
+		}
 	}
-	return tr
+	if fallback != nil {
+		return fallback.GetND(dom, str, plural, n, vars...)
+	}
+	if n == 1 {
+		return FormatString(str, vars...)
+	}
+	return FormatString(plural, vars...)
 }
 
 // GetC uses the default domain globally set to return the corresponding Translation of the given string in the given context.
@@ -305,18 +345,24 @@ func GetDC(dom, str, ctx string, vars ...any) string {
 	// Try to load default package Locales
 	loadLocales(false)
 
-	globalConfig.RLock()
-	defer globalConfig.RUnlock()
-
-	var tr string
-	for i, locale := range globalConfig.locales {
-		if !locale.IsTranslatedDC(dom, str, ctx) && i < (len(globalConfig.locales)-1) {
+	locales := GetLocales()
+	var fallback *Locale
+	for _, locale := range locales {
+		if locale == nil {
 			continue
 		}
-		tr = locale.GetDC(dom, str, ctx, vars...)
-		break
+		fallback = locale
+		if !locale.hasDomain(dom) {
+			locale.AddDomain(dom)
+		}
+		if locale.IsTranslatedDC(dom, str, ctx) {
+			return locale.GetDC(dom, str, ctx, vars...)
+		}
 	}
-	return tr
+	if fallback != nil {
+		return fallback.GetDC(dom, str, ctx, vars...)
+	}
+	return FormatString(str, vars...)
 }
 
 // GetNDC retrieves the (N)th plural form of Translation in the given domain for a given string.
@@ -325,19 +371,27 @@ func GetNDC(dom, str, plural string, n int, ctx string, vars ...any) string {
 	// Try to load default package Locales
 	loadLocales(false)
 
-	// Return Translation
-	globalConfig.RLock()
-	defer globalConfig.RUnlock()
-
-	var tr string
-	for i, locale := range globalConfig.locales {
-		if !locale.IsTranslatedNDC(dom, str, n, ctx) && i < (len(globalConfig.locales)-1) {
+	locales := GetLocales()
+	var fallback *Locale
+	for _, locale := range locales {
+		if locale == nil {
 			continue
 		}
-		tr = locale.GetNDC(dom, str, plural, n, ctx, vars...)
-		break
+		fallback = locale
+		if !locale.hasDomain(dom) {
+			locale.AddDomain(dom)
+		}
+		if locale.IsTranslatedNDC(dom, str, n, ctx) {
+			return locale.GetNDC(dom, str, plural, n, ctx, vars...)
+		}
 	}
-	return tr
+	if fallback != nil {
+		return fallback.GetNDC(dom, str, plural, n, ctx, vars...)
+	}
+	if n == 1 {
+		return FormatString(str, vars...)
+	}
+	return FormatString(plural, vars...)
 }
 
 // IsTranslated reports whether a string is translated in given languages.
@@ -366,14 +420,14 @@ func IsTranslatedND(dom, str string, n int, langs ...string) bool {
 	}
 
 	loadLocales(false)
-
-	globalConfig.RLock()
-	defer globalConfig.RUnlock()
-
+	locales := GetLocales()
 	for _, lang := range langs {
 		lang = SimplifiedLocale(lang)
 
-		for _, supportedLocale := range globalConfig.locales {
+		for _, supportedLocale := range locales {
+			if supportedLocale == nil {
+				continue
+			}
 			if lang != supportedLocale.GetActualLanguage(dom) {
 				continue
 			}
@@ -409,18 +463,18 @@ func IsTranslatedNDC(dom, str string, n int, ctx string, langs ...string) bool {
 	}
 
 	loadLocales(false)
-
-	globalConfig.RLock()
-	defer globalConfig.RUnlock()
-
+	locales := GetLocales()
 	for _, lang := range langs {
 		lang = SimplifiedLocale(lang)
 
-		for _, locale := range globalConfig.locales {
-			if lang != locale.GetActualLanguage(dom) {
+		for _, supportedLocale := range locales {
+			if supportedLocale == nil {
 				continue
 			}
-			return locale.IsTranslatedNDC(dom, str, n, ctx)
+			if lang != supportedLocale.GetActualLanguage(dom) {
+				continue
+			}
+			return supportedLocale.IsTranslatedNDC(dom, str, n, ctx)
 		}
 	}
 	return false

--- a/gotext.go
+++ b/gotext.go
@@ -140,7 +140,7 @@ func GetLanguages() []string {
 func SetLanguage(lang string) {
 	globalConfig.Lock()
 	var languages []string
-	for _, language := range strings.Split(lang, ":") {
+	for language := range strings.SplitSeq(lang, ":") {
 		languages = append(languages, SimplifiedLocale(language))
 	}
 	globalConfig.languages = languages
@@ -219,7 +219,7 @@ func Configure(lib, lang, dom string) {
 	globalConfig.Lock()
 	globalConfig.library = lib
 	var languages []string
-	for _, language := range strings.Split(lang, ":") {
+	for language := range strings.SplitSeq(lang, ":") {
 		languages = append(languages, SimplifiedLocale(language))
 	}
 	globalConfig.languages = languages

--- a/gotext_test.go
+++ b/gotext_test.go
@@ -740,3 +740,168 @@ func TestGotext_MissingWrappers(t *testing.T) {
 		t.Error("GetD failed")
 	}
 }
+func TestGlobalEmptyLocaleStorageIsSafe(t *testing.T) {
+	previousLocales := GetLocales()
+	previousLanguages := GetLanguages()
+	previousLibrary := GetLibrary()
+	previousDomain := GetDomain()
+	defer func() {
+		globalConfig.Lock()
+		globalConfig.locales = append(make([]*Locale, 0, len(previousLocales)), previousLocales...)
+		globalConfig.languages = append(make([]string, 0, len(previousLanguages)), previousLanguages...)
+		globalConfig.library = previousLibrary
+		globalConfig.domain = previousDomain
+		globalConfig.Unlock()
+	}()
+
+	tests := []struct {
+		name   string
+		setter func()
+		count  int
+	}{
+		{name: "nil", setter: func() { SetLocales(nil) }},
+		{name: "empty", setter: func() { SetLocales([]*Locale{}) }},
+		{name: "nil element", setter: func() { SetLocales([]*Locale{nil}) }, count: 1},
+		{name: "nil storage", setter: func() { SetStorage(nil) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setter()
+
+			if got := len(GetLocales()); got != tt.count {
+				t.Fatalf("GetLocales length = %d, want %d", got, tt.count)
+			}
+			if got := GetDomain(); got != previousDomain {
+				t.Errorf("GetDomain = %q, want configured fallback %q", got, previousDomain)
+			}
+			if got := GetLibrary(); got != previousLibrary {
+				t.Errorf("GetLibrary = %q, want configured fallback %q", got, previousLibrary)
+			}
+			if got := GetLanguage(); got != FallbackLocale {
+				t.Errorf("GetLanguage = %q, want fallback %q", got, FallbackLocale)
+			}
+			if got := len(GetLanguages()); got != 0 {
+				t.Errorf("GetLanguages length = %d, want 0", got)
+			}
+			if got := Get("source %s", "value"); got != "source value" {
+				t.Errorf("Get fallback = %q, want %q", got, "source value")
+			}
+			if got := GetN("one", "many", 1); got != "one" {
+				t.Errorf("GetN singular fallback = %q, want %q", got, "one")
+			}
+			if got := GetN("one", "many", 2); got != "many" {
+				t.Errorf("GetN plural fallback = %q, want %q", got, "many")
+			}
+			if got := GetC("source", "context"); got != "source" {
+				t.Errorf("GetC fallback = %q, want %q", got, "source")
+			}
+			if got := GetNC("one", "many", 2, "context"); got != "many" {
+				t.Errorf("GetNC plural fallback = %q, want %q", got, "many")
+			}
+			if GetStorage() != nil {
+				t.Error("GetStorage should be nil for an empty/nil locale state")
+			}
+		})
+	}
+}
+
+func TestSetLocalesCopiesCallerSlices(t *testing.T) {
+	previousLocales := GetLocales()
+	previousLanguages := GetLanguages()
+	previousLibrary := GetLibrary()
+	previousDomain := GetDomain()
+	defer func() {
+		globalConfig.Lock()
+		globalConfig.locales = append(make([]*Locale, 0, len(previousLocales)), previousLocales...)
+		globalConfig.languages = append(make([]string, 0, len(previousLanguages)), previousLanguages...)
+		globalConfig.library = previousLibrary
+		globalConfig.domain = previousDomain
+		globalConfig.Unlock()
+	}()
+
+	locale := NewLocale("caller-path", "caller")
+	locale.SetDomain("caller-domain")
+	input := []*Locale{locale}
+	SetLocales(input)
+	input[0] = nil
+
+	if got := GetStorage(); got != locale {
+		t.Fatalf("mutating SetLocales input changed storage: got %p, want %p", got, locale)
+	}
+
+	output := GetLocales()
+	output[0] = nil
+	if got := GetStorage(); got != locale {
+		t.Fatalf("mutating GetLocales result changed storage: got %p, want %p", got, locale)
+	}
+
+	languages := GetLanguages()
+	languages[0] = "mutated"
+	if got := GetLanguage(); got != "caller" {
+		t.Errorf("mutating GetLanguages result changed storage: got %q, want %q", got, "caller")
+	}
+}
+
+func TestConcurrentSetDomainKeepsGlobalAndLocaleDomainsInSync(t *testing.T) {
+	globalConfig.RLock()
+	previousLocales := append(make([]*Locale, 0, len(globalConfig.locales)), globalConfig.locales...)
+	previousLanguages := append(make([]string, 0, len(globalConfig.languages)), globalConfig.languages...)
+	previousLibrary := globalConfig.library
+	previousDomain := globalConfig.domain
+	globalConfig.RUnlock()
+	defer func() {
+		globalConfig.Lock()
+		globalConfig.locales = previousLocales
+		globalConfig.languages = previousLanguages
+		globalConfig.library = previousLibrary
+		globalConfig.domain = previousDomain
+		globalConfig.Unlock()
+	}()
+
+	SetLocales([]*Locale{
+		NewLocale("", "en_US"),
+		NewLocale("", "fr_FR"),
+	})
+
+	domains := []string{"domain-a", "domain-b", "domain-c", "domain-d"}
+	const setterCount = 32
+	const rounds = 8
+	start := make(chan struct{})
+	var setters sync.WaitGroup
+	setters.Add(setterCount)
+	for worker := range setterCount {
+		go func(worker int) {
+			defer setters.Done()
+			<-start
+			for round := range rounds {
+				SetDomain(domains[(worker+round)%len(domains)])
+			}
+		}(worker)
+	}
+	close(start)
+	setters.Wait()
+
+	globalConfig.RLock()
+	authoritativeDomain := globalConfig.domain
+	installedLocales := append(make([]*Locale, 0, len(globalConfig.locales)), globalConfig.locales...)
+	globalConfig.RUnlock()
+
+	if got := GetDomain(); got != authoritativeDomain {
+		t.Fatalf("GetDomain = %q, want authoritative global domain %q", got, authoritativeDomain)
+	}
+
+	installed := 0
+	for i, locale := range installedLocales {
+		if locale == nil {
+			continue
+		}
+		installed++
+		if got := locale.GetDomain(); got != authoritativeDomain {
+			t.Errorf("installed locale %d GetDomain = %q, want authoritative global domain %q", i, got, authoritativeDomain)
+		}
+	}
+	if installed == 0 {
+		t.Fatal("concurrent SetDomain test installed no nonnil locales")
+	}
+}

--- a/gotext_test.go
+++ b/gotext_test.go
@@ -733,8 +733,6 @@ func TestGotext_MissingWrappers(t *testing.T) {
 		t.Error("GetStorage should not be nil")
 	}
 
-	SetStorage(GetStorage()) // Coverage
-
 	Configure("fixtures", "en_US", "default")
 	if GetD("default", "My text") != translatedText {
 		t.Error("GetD failed")

--- a/gotext_test.go
+++ b/gotext_test.go
@@ -480,11 +480,14 @@ func TestOverrideLocale(t *testing.T) {
 
 func TestPackageRace(t *testing.T) {
 	// Set PO content
-	str := `# Some comment
+	str := `msgid ""
+msgstr ""
+"Language: en_US\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
 msgid "My text"
 msgstr "Translated text"
 
-# More comments
 msgid "Another string"
 msgstr ""
 
@@ -497,55 +500,56 @@ msgstr[2] "And this is the second plural form: %s"
 msgctxt "Ctx"
 msgid "Some random in a context"
 msgstr "Some random Translation in a context"
-
 	`
 
-	// Create Locales directory on default location
-	dirname := path.Join("/tmp", "en_US")
+	library := t.TempDir()
+	dirname := filepath.Join(library, "en_US")
 	err := os.MkdirAll(dirname, os.ModePerm)
 	if err != nil {
 		t.Fatalf("Can't create test directory: %s", err.Error())
 	}
 
-	// Write PO content to default domain file
-	filename := path.Join("/tmp", GetDomain()+".po")
-
-	f, err := os.Create(filename)
-	if err != nil {
-		t.Fatalf("Can't create test file: %s", err.Error())
-	}
-	defer func() {
-		_ = f.Close()
-	}()
-
-	_, err = f.WriteString(str)
+	filename := filepath.Join(dirname, "default.po")
+	err = os.WriteFile(filename, []byte(str), 0o644)
 	if err != nil {
 		t.Fatalf("Can't write to test file: %s", err.Error())
 	}
 
+	Configure(library, "en_US", "default")
+
 	var wg sync.WaitGroup
+	results := make(chan [2]string, 1000)
 
-	for i := 0; i < 1000; i++ {
-		wg.Add(1)
-		// Test translations
-		go func() {
-			defer wg.Done()
-
+	for range 1000 {
+		wg.Go(func() {
+			// Test translations
 			GetLibrary()
-			SetLibrary(path.Join("/tmp", "gotextlib"))
+			SetLibrary(library)
 			GetDomain()
 			SetDomain("default")
 			GetLanguage()
 			SetLanguage("en_US")
-			Configure("/tmp", "en_US", "default")
+			Configure(library, "en_US", "default")
 
-			Get("My text")
+			results <- [2]string{
+				Get("My text"),
+				GetC("Some random in a context", "Ctx"),
+			}
 			GetN("One with var: %s", "Several with vars: %s", 0, "test")
-			GetC("Some random in a context", "Ctx")
-		}()
+		})
 	}
 
 	wg.Wait()
+	close(results)
+
+	for result := range results {
+		if result[0] != "Translated text" {
+			t.Errorf("Expected 'Translated text', got '%s'", result[0])
+		}
+		if result[1] != "Some random Translation in a context" {
+			t.Errorf("Expected contextual translation, got '%s'", result[1])
+		}
+	}
 }
 
 func TestPackageArabicTranslation(t *testing.T) {
@@ -724,13 +728,13 @@ func TestGotext_MissingWrappers(t *testing.T) {
 	if IsTranslatedDC("missing", "id", "ctx") {
 		t.Error("IsTranslatedDC failed")
 	}
-	
+
 	if GetStorage() == nil {
 		t.Error("GetStorage should not be nil")
 	}
-	
+
 	SetStorage(GetStorage()) // Coverage
-	
+
 	Configure("fixtures", "en_US", "default")
 	if GetD("default", "My text") != translatedText {
 		t.Error("GetD failed")

--- a/helper.go
+++ b/helper.go
@@ -69,33 +69,32 @@ func Sprintf(format string, params map[string]any) string {
 func parseSprintf(format string, params map[string]any) (string, []any) {
 	f, n := reformatSprintf(format)
 	var p []any
-	for _, v := range n {
-		p = append(p, params[v])
+	if len(n) > 0 {
+		p = make([]any, len(n))
+		for i, v := range n {
+			p[i] = params[v]
+		}
 	}
 	return f, p
 }
 
 func reformatSprintf(f string) (string, []string) {
-	m := re.FindAllStringSubmatch(f, -1)
-	i := re.FindAllStringSubmatchIndex(f, -1)
+	matches := re.FindAllStringSubmatchIndex(f, -1)
+	ord := make([]string, 0, len(matches))
+	pair := make([]int, 1, 1+2*len(matches))
+	pair[0] = 0
 
-	ord := []string{}
-	for _, v := range m {
-		ord = append(ord, v[1])
-	}
-
-	pair := []int{0}
-	for _, v := range i {
-		pair = append(pair, v[2]-1)
-		pair = append(pair, v[3]+1)
+	for _, match := range matches {
+		ord = append(ord, f[match[2]:match[3]])
+		pair = append(pair, match[2]-1, match[3]+1)
 	}
 	pair = append(pair, len(f))
-	plen := len(pair)
 
-	out := ""
-	for n := 0; n < plen; n += 2 {
-		out += f[pair[n]:pair[n+1]]
+	var out strings.Builder
+	out.Grow(len(f))
+	for n := 0; n < len(pair); n += 2 {
+		out.WriteString(f[pair[n]:pair[n+1]])
 	}
 
-	return out, ord
+	return out.String(), ord
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -118,3 +118,83 @@ func TestHelper_Appendf(t *testing.T) {
 		t.Errorf("Expected 'test: Hello World', got '%s'", string(res))
 	}
 }
+
+func TestReformatSprintfEdgeCases(t *testing.T) {
+	tests := []struct {
+		name       string
+		format     string
+		wantFormat string
+		wantNames  []string
+	}{
+		{
+			name:       "repeated names",
+			format:     "%(name)s %(name)q",
+			wantFormat: "%s %q",
+			wantNames:  []string{"name", "name"},
+		},
+		{
+			name:       "width and precision",
+			format:     "%(amount)08.2f",
+			wantFormat: "%08.2f",
+			wantNames:  []string{"amount"},
+		},
+		{
+			name:       "adjacent placeholders",
+			format:     "%(left)s%(right)d",
+			wantFormat: "%s%d",
+			wantNames:  []string{"left", "right"},
+		},
+		{
+			name:       "no placeholders",
+			format:     "literal text",
+			wantFormat: "literal text",
+			wantNames:  []string{},
+		},
+		{
+			name:       "long placeholder list",
+			format:     "%(p0)s %(p1)s %(p2)s %(p3)s %(p4)s %(p5)s %(p6)s %(p7)s %(p8)s %(p9)s",
+			wantFormat: "%s %s %s %s %s %s %s %s %s %s",
+			wantNames:  []string{"p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9"},
+		},
+		{
+			name:       "malformed placeholders",
+			format:     "%(bad-name)s %(unterminated",
+			wantFormat: "%(bad-name)s %(unterminated",
+			wantNames:  []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotFormat, gotNames := reformatSprintf(test.format)
+			if gotFormat != test.wantFormat {
+				t.Errorf("rewritten format = %q, want %q", gotFormat, test.wantFormat)
+			}
+			if !reflect.DeepEqual(gotNames, test.wantNames) {
+				t.Errorf("ordered names = %v, want %v", gotNames, test.wantNames)
+			}
+		})
+	}
+}
+
+func TestParseSprintfPreservesArgumentOrder(t *testing.T) {
+	format := "%(first)s%(second)d%(first)s"
+	params := map[string]any{
+		"first":  "one",
+		"second": 2,
+	}
+
+	gotFormat, gotParams := parseSprintf(format, params)
+	if gotFormat != "%s%d%s" {
+		t.Errorf("rewritten format = %q, want %q", gotFormat, "%s%d%s")
+	}
+	wantParams := []any{"one", 2, "one"}
+	if !reflect.DeepEqual(gotParams, wantParams) {
+		t.Errorf("ordered params = %v, want %v", gotParams, wantParams)
+	}
+
+	_, gotParams = parseSprintf("%(bad-name)s", params)
+	if gotParams != nil {
+		t.Errorf("malformed format should have no bound params, got %v", gotParams)
+	}
+}

--- a/helper_test.go
+++ b/helper_test.go
@@ -6,6 +6,8 @@
 package gotext
 
 import (
+	"io"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -90,8 +92,31 @@ func TestNPrintf(t *testing.T) {
 		"brother": "Louis",
 	}
 
+	originalStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := reader.Close(); err != nil {
+			t.Errorf("closing stdout reader: %v", err)
+		}
+	})
+	os.Stdout = writer
 	NPrintf(pat, params)
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = originalStdout
 
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "Louis loves Susan. Susan also loves Louis.\n"
+	if string(output) != want {
+		t.Errorf("NPrintf output = %q, want %q", output, want)
+	}
 }
 
 func TestSprintfFloatsWithPrecision(t *testing.T) {

--- a/locale.go
+++ b/locale.go
@@ -91,91 +91,111 @@ func NewLocaleFSWithPath(l string, filesystem fs.FS, p string) *Locale {
 	return loc
 }
 
-func (l *Locale) findExt(dom, ext string) string {
-	filename := path.Join(l.path, l.lang, "LC_MESSAGES", dom+"."+ext)
-	if l.fileExists(filename) {
-		return filename
+func (l *Locale) snapshotPathLanguageFS() (string, string, fs.FS) {
+	if l == nil {
+		return "", "", nil
 	}
 
-	if len(l.lang) > 2 {
-		filename = path.Join(l.path, l.lang[:2], "LC_MESSAGES", dom+"."+ext)
-		if l.fileExists(filename) {
-			return filename
-		}
-	}
-
-	filename = path.Join(l.path, l.lang, dom+"."+ext)
-	if l.fileExists(filename) {
-		return filename
-	}
-
-	if len(l.lang) > 2 {
-		filename = path.Join(l.path, l.lang[:2], dom+"."+ext)
-		if l.fileExists(filename) {
-			return filename
-		}
-	}
-
-	return ""
+	l.RLock()
+	p := l.path
+	lang := l.lang
+	filesystem := l.fs
+	l.RUnlock()
+	return p, lang, filesystem
 }
 
-// GetActualLanguage inspects the filesystem and decides whether to strip
-// a CC part of the ll_CC locale string.
-func (l *Locale) GetActualLanguage(dom string) string {
-	extensions := []string{"mo", "po"}
-	var fp string
-	for _, ext := range extensions {
-		// 'll' (or 'll_CC') exists, and it was specified as-is
-		fp = path.Join(l.path, l.lang, "LC_MESSAGES", dom+"."+ext)
-		if l.fileExists(fp) {
-			return l.lang
-		}
-		// 'll' exists, but 'll_CC' was specified
-		if len(l.lang) > 2 {
-			fp = path.Join(l.path, l.lang[:2], "LC_MESSAGES", dom+"."+ext)
-			if l.fileExists(fp) {
-				return l.lang[:2]
-			}
-		}
-		// 'll' (or 'll_CC') exists outside of LC_category, and it was specified as-is
-		fp = path.Join(l.path, l.lang, dom+"."+ext)
-		if l.fileExists(fp) {
-			return l.lang
-		}
-		// 'll' exists outside of LC_category, but 'll_CC' was specified
-		if len(l.lang) > 2 {
-			fp = path.Join(l.path, l.lang[:2], dom+"."+ext)
-			if l.fileExists(fp) {
-				return l.lang[:2]
-			}
-		}
-	}
-	return ""
-}
-
-func (l *Locale) fileExists(filename string) bool {
-	if l.fs != nil {
-		_, err := fs.Stat(l.fs, filename)
+func fileExistsIn(filesystem fs.FS, filename string) bool {
+	if filesystem != nil {
+		_, err := fs.Stat(filesystem, filename)
 		return err == nil
 	}
 	_, err := os.Stat(filename)
 	return err == nil
 }
 
+func (l *Locale) findExtWithFS(dom, ext string) (fs.FS, string) {
+	p, lang, filesystem := l.snapshotPathLanguageFS()
+
+	filename := path.Join(p, lang, "LC_MESSAGES", dom+"."+ext)
+	if fileExistsIn(filesystem, filename) {
+		return filesystem, filename
+	}
+
+	if len(lang) > 2 {
+		filename = path.Join(p, lang[:2], "LC_MESSAGES", dom+"."+ext)
+		if fileExistsIn(filesystem, filename) {
+			return filesystem, filename
+		}
+	}
+
+	filename = path.Join(p, lang, dom+"."+ext)
+	if fileExistsIn(filesystem, filename) {
+		return filesystem, filename
+	}
+
+	if len(lang) > 2 {
+		filename = path.Join(p, lang[:2], dom+"."+ext)
+		if fileExistsIn(filesystem, filename) {
+			return filesystem, filename
+		}
+	}
+
+	return filesystem, ""
+}
+
+// GetActualLanguage inspects the filesystem and decides whether to strip
+// a CC part of the ll_CC locale string.
+func (l *Locale) GetActualLanguage(dom string) string {
+	p, lang, filesystem := l.snapshotPathLanguageFS()
+	extensions := []string{"mo", "po"}
+	var fp string
+	for _, ext := range extensions {
+		// 'll' (or 'll_CC') exists, and it was specified as-is
+		fp = path.Join(p, lang, "LC_MESSAGES", dom+"."+ext)
+		if fileExistsIn(filesystem, fp) {
+			return lang
+		}
+		// 'll' exists, but 'll_CC' was specified
+		if len(lang) > 2 {
+			fp = path.Join(p, lang[:2], "LC_MESSAGES", dom+"."+ext)
+			if fileExistsIn(filesystem, fp) {
+				return lang[:2]
+			}
+		}
+		// 'll' (or 'll_CC') exists outside of LC_category, and it was specified as-is
+		fp = path.Join(p, lang, dom+"."+ext)
+		if fileExistsIn(filesystem, fp) {
+			return lang
+		}
+		// 'll' exists outside of LC_category, but 'll_CC' was specified
+		if len(lang) > 2 {
+			fp = path.Join(p, lang[:2], dom+"."+ext)
+			if fileExistsIn(filesystem, fp) {
+				return lang[:2]
+			}
+		}
+	}
+	return ""
+}
+
 // AddDomain creates a new domain for a given locale object and initializes the Po object.
 // If the domain exists, it gets reloaded.
 func (l *Locale) AddDomain(dom string) {
+	if l == nil {
+		return
+	}
+
 	var poObj Translator
 
-	file := l.findExt(dom, "po")
+	filesystem, file := l.findExtWithFS(dom, "po")
 	if file != "" {
-		poObj = NewPoFS(l.fs)
+		poObj = NewPoFS(filesystem)
 		// Parse file.
 		poObj.ParseFile(file)
 	} else {
-		file = l.findExt(dom, "mo")
+		filesystem, file = l.findExtWithFS(dom, "mo")
 		if file != "" {
-			poObj = NewMoFS(l.fs)
+			poObj = NewMoFS(filesystem)
 			// Parse file.
 			poObj.ParseFile(file)
 		} else {
@@ -213,9 +233,34 @@ func (l *Locale) AddTranslator(dom string, tr Translator) {
 
 	l.Unlock()
 }
+func (l *Locale) translatorFor(dom string) Translator {
+	if l == nil {
+		return nil
+	}
+
+	l.RLock()
+	translator := l.Domains[dom]
+	l.RUnlock()
+	return translator
+}
+
+func (l *Locale) hasDomain(dom string) bool {
+	if l == nil {
+		return false
+	}
+
+	l.RLock()
+	_, ok := l.Domains[dom]
+	l.RUnlock()
+	return ok
+}
 
 // GetDomain is the domain getter for Locale configuration
 func (l *Locale) GetDomain() string {
+	if l == nil {
+		return ""
+	}
+
 	l.RLock()
 	dom := l.defaultDomain
 	l.RUnlock()
@@ -224,6 +269,10 @@ func (l *Locale) GetDomain() string {
 
 // SetDomain sets the name for the domain to be used.
 func (l *Locale) SetDomain(dom string) {
+	if l == nil {
+		return
+	}
+
 	l.Lock()
 	l.defaultDomain = dom
 	l.Unlock()
@@ -231,6 +280,10 @@ func (l *Locale) SetDomain(dom string) {
 
 // GetLanguage is the lang getter for Locale configuration
 func (l *Locale) GetLanguage() string {
+	if l == nil {
+		return ""
+	}
+
 	l.RLock()
 	lang := l.lang
 	l.RUnlock()
@@ -252,16 +305,9 @@ func (l *Locale) GetN(str, plural string, n int, vars ...any) string {
 // GetD returns the corresponding Translation in the given domain for the given string.
 // Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
 func (l *Locale) GetD(dom, str string, vars ...any) string {
-	// Sync read
-	l.RLock()
-	defer l.RUnlock()
-
-	if l.Domains != nil {
-		if _, ok := l.Domains[dom]; ok {
-			if l.Domains[dom] != nil {
-				return l.Domains[dom].Get(str, vars...)
-			}
-		}
+	translator := l.translatorFor(dom)
+	if translator != nil {
+		return translator.Get(str, vars...)
 	}
 
 	return FormatString(str, vars...)
@@ -270,16 +316,9 @@ func (l *Locale) GetD(dom, str string, vars ...any) string {
 // GetND retrieves the (N)th plural form of Translation in the given domain for the given string.
 // Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
 func (l *Locale) GetND(dom, str, plural string, n int, vars ...any) string {
-	// Sync read
-	l.RLock()
-	defer l.RUnlock()
-
-	if l.Domains != nil {
-		if _, ok := l.Domains[dom]; ok {
-			if l.Domains[dom] != nil {
-				return l.Domains[dom].GetN(str, plural, n, vars...)
-			}
-		}
+	translator := l.translatorFor(dom)
+	if translator != nil {
+		return translator.GetN(str, plural, n, vars...)
 	}
 
 	// Use western default rule (plural > 1) to handle missing domain default result.
@@ -304,16 +343,9 @@ func (l *Locale) GetNC(str, plural string, n int, ctx string, vars ...any) strin
 // GetDC returns the corresponding Translation in the given domain for the given string in the given context.
 // Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
 func (l *Locale) GetDC(dom, str, ctx string, vars ...any) string {
-	// Sync read
-	l.RLock()
-	defer l.RUnlock()
-
-	if l.Domains != nil {
-		if _, ok := l.Domains[dom]; ok {
-			if l.Domains[dom] != nil {
-				return l.Domains[dom].GetC(str, ctx, vars...)
-			}
-		}
+	translator := l.translatorFor(dom)
+	if translator != nil {
+		return translator.GetC(str, ctx, vars...)
 	}
 
 	return FormatString(str, vars...)
@@ -322,16 +354,9 @@ func (l *Locale) GetDC(dom, str, ctx string, vars ...any) string {
 // GetNDC retrieves the (N)th plural form of Translation in the given domain for the given string in the given context.
 // Supports optional parameters (vars... any) to be inserted on the formatted string using the fmt.Printf syntax.
 func (l *Locale) GetNDC(dom, str, plural string, n int, ctx string, vars ...any) string {
-	// Sync read
-	l.RLock()
-	defer l.RUnlock()
-
-	if l.Domains != nil {
-		if _, ok := l.Domains[dom]; ok {
-			if l.Domains[dom] != nil {
-				return l.Domains[dom].GetNC(str, plural, n, ctx, vars...)
-			}
-		}
+	translator := l.translatorFor(dom)
+	if translator != nil {
+		return translator.GetNC(str, plural, n, ctx, vars...)
 	}
 
 	// Use western default rule (plural > 1) to handle missing domain default result.
@@ -344,11 +369,26 @@ func (l *Locale) GetNDC(dom, str, plural string, n int, ctx string, vars ...any)
 // GetTranslations returns a copy of all translations in all domains of this locale. It does not support contexts.
 func (l *Locale) GetTranslations() map[string]*Translation {
 	all := make(map[string]*Translation)
+	if l == nil {
+		return all
+	}
 
 	l.RLock()
-	defer l.RUnlock()
+	translators := make([]Translator, 0, len(l.Domains))
 	for _, translator := range l.Domains {
-		maps.Copy(all, translator.GetDomain().GetTranslations())
+		translators = append(translators, translator)
+	}
+	l.RUnlock()
+
+	for _, translator := range translators {
+		if translator == nil {
+			continue
+		}
+		domain := translator.GetDomain()
+		if domain == nil {
+			continue
+		}
+		maps.Copy(all, domain.GetTranslations())
 	}
 
 	return all
@@ -371,17 +411,15 @@ func (l *Locale) IsTranslatedD(dom, str string) bool {
 
 // IsTranslatedND reports whether a plural domain string is translated
 func (l *Locale) IsTranslatedND(dom, str string, n int) bool {
-	l.RLock()
-	defer l.RUnlock()
-
-	if l.Domains == nil {
+	translator := l.translatorFor(dom)
+	if translator == nil {
 		return false
 	}
-	translator, ok := l.Domains[dom]
-	if !ok {
+	domain := translator.GetDomain()
+	if domain == nil {
 		return false
 	}
-	return translator.GetDomain().IsTranslatedN(str, n)
+	return domain.IsTranslatedN(str, n)
 }
 
 // IsTranslatedC reports whether a context string is translated
@@ -401,17 +439,15 @@ func (l *Locale) IsTranslatedDC(dom, str, ctx string) bool {
 
 // IsTranslatedNDC reports whether a plural domain context string is translated
 func (l *Locale) IsTranslatedNDC(dom string, str string, n int, ctx string) bool {
-	l.RLock()
-	defer l.RUnlock()
-
-	if l.Domains == nil {
+	translator := l.translatorFor(dom)
+	if translator == nil {
 		return false
 	}
-	translator, ok := l.Domains[dom]
-	if !ok {
+	domain := translator.GetDomain()
+	if domain == nil {
 		return false
 	}
-	return translator.GetDomain().IsTranslatedNC(str, n, ctx)
+	return domain.IsTranslatedNC(str, n, ctx)
 }
 
 // LocaleEncoding is used as intermediary storage to encode Locale objects to Gob.
@@ -424,26 +460,34 @@ type LocaleEncoding struct {
 
 // MarshalBinary implements encoding BinaryMarshaler interface
 func (l *Locale) MarshalBinary() ([]byte, error) {
-	l.RLock()
-	path := l.path
-	lang := l.lang
-	defaultDomain := l.defaultDomain
-	domains := make(map[string]Translator, len(l.Domains))
-	maps.Copy(domains, l.Domains)
-	l.RUnlock()
+	var localePath, lang, defaultDomain string
+	domains := make(map[string]Translator)
+	if l != nil {
+		l.RLock()
+		localePath = l.path
+		lang = l.lang
+		defaultDomain = l.defaultDomain
+		domains = make(map[string]Translator, len(l.Domains))
+		for name, translator := range l.Domains {
+			if translator != nil {
+				domains[name] = translator
+			}
+		}
+		l.RUnlock()
+	}
 
 	obj := &LocaleEncoding{
-		Path:          path,
+		Path:          localePath,
 		Lang:          lang,
 		Domains:       make(map[string][]byte, len(domains)),
 		DefaultDomain: defaultDomain,
 	}
-	for k, v := range domains {
-		var err error
-		obj.Domains[k], err = v.MarshalBinary()
+	for name, translator := range domains {
+		data, err := translator.MarshalBinary()
 		if err != nil {
 			return nil, err
 		}
+		obj.Domains[name] = data
 	}
 
 	var buff bytes.Buffer

--- a/locale.go
+++ b/locale.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"io/fs"
+	"maps"
 	"os"
 	"path"
 	"sync"
@@ -347,9 +348,7 @@ func (l *Locale) GetTranslations() map[string]*Translation {
 	l.RLock()
 	defer l.RUnlock()
 	for _, translator := range l.Domains {
-		for msgID, trans := range translator.GetDomain().GetTranslations() {
-			all[msgID] = trans
-		}
+		maps.Copy(all, translator.GetDomain().GetTranslations())
 	}
 
 	return all
@@ -425,18 +424,27 @@ type LocaleEncoding struct {
 
 // MarshalBinary implements encoding BinaryMarshaler interface
 func (l *Locale) MarshalBinary() ([]byte, error) {
-	obj := new(LocaleEncoding)
-	obj.DefaultDomain = l.defaultDomain
-	obj.Domains = make(map[string][]byte)
-	for k, v := range l.Domains {
+	l.RLock()
+	path := l.path
+	lang := l.lang
+	defaultDomain := l.defaultDomain
+	domains := make(map[string]Translator, len(l.Domains))
+	maps.Copy(domains, l.Domains)
+	l.RUnlock()
+
+	obj := &LocaleEncoding{
+		Path:          path,
+		Lang:          lang,
+		Domains:       make(map[string][]byte, len(domains)),
+		DefaultDomain: defaultDomain,
+	}
+	for k, v := range domains {
 		var err error
 		obj.Domains[k], err = v.MarshalBinary()
 		if err != nil {
 			return nil, err
 		}
 	}
-	obj.Lang = l.lang
-	obj.Path = l.path
 
 	var buff bytes.Buffer
 	encoder := gob.NewEncoder(&buff)
@@ -445,7 +453,7 @@ func (l *Locale) MarshalBinary() ([]byte, error) {
 	return buff.Bytes(), err
 }
 
-// UnmarshalBinary implements encoding BinaryUnmarshaler interface
+// UnmarshalBinary implements encoding.BinaryUnmarshaler interface
 func (l *Locale) UnmarshalBinary(data []byte) error {
 	buff := bytes.NewBuffer(data)
 	obj := new(LocaleEncoding)
@@ -456,12 +464,7 @@ func (l *Locale) UnmarshalBinary(data []byte) error {
 		return err
 	}
 
-	l.defaultDomain = obj.DefaultDomain
-	l.lang = obj.Lang
-	l.path = obj.Path
-
-	// Decode Domains
-	l.Domains = make(map[string]Translator)
+	domains := make(map[string]Translator, len(obj.Domains))
 	for k, v := range obj.Domains {
 		var tr TranslatorEncoding
 		buff := bytes.NewBuffer(v)
@@ -471,8 +474,15 @@ func (l *Locale) UnmarshalBinary(data []byte) error {
 			return err
 		}
 
-		l.Domains[k] = tr.GetTranslator()
+		domains[k] = tr.GetTranslator()
 	}
+
+	l.Lock()
+	l.defaultDomain = obj.DefaultDomain
+	l.lang = obj.Lang
+	l.path = obj.Path
+	l.Domains = domains
+	l.Unlock()
 
 	return nil
 }

--- a/locale_test.go
+++ b/locale_test.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"os"
 	"path"
-	"reflect"
 	"sync"
 	"testing"
 	"testing/fstest"
@@ -23,12 +22,37 @@ type reentrantTranslator struct {
 	locale     *Locale
 	po         *Po
 	marshalErr error
+	calls      map[string]int
 }
 
 func newReentrantTranslator(locale *Locale) *reentrantTranslator {
 	po := NewPo()
 	po.Set("message", "translated")
-	return &reentrantTranslator{locale: locale, po: po}
+	po.SetN("message", "messages", 2, "plural translated")
+	po.SetC("message", "context", "context translated")
+	po.SetNC("message", "messages", "context", 2, "context plural translated")
+	return &reentrantTranslator{locale: locale, po: po, calls: make(map[string]int)}
+}
+func waitForLocaleCall(t *testing.T, call func()) {
+	t.Helper()
+
+	done := make(chan struct{}, 1)
+	go func() {
+		call()
+		done <- struct{}{}
+	}()
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-timer.C:
+		t.Fatal("Locale call deadlocked while translator mutated its Locale")
+	}
+}
+
+func (tr *reentrantTranslator) record(name string) {
+	tr.calls[name]++
 }
 
 func (tr *reentrantTranslator) mutateLocale() {
@@ -38,46 +62,54 @@ func (tr *reentrantTranslator) mutateLocale() {
 }
 
 func (tr *reentrantTranslator) ParseFile(f string) {
+	tr.record("ParseFile")
 	tr.po.ParseFile(f)
 }
 
 func (tr *reentrantTranslator) Parse(data []byte) {
+	tr.record("Parse")
 	tr.po.Parse(data)
 }
 
 func (tr *reentrantTranslator) Get(str string, vars ...any) string {
+	tr.record("Get")
 	tr.mutateLocale()
 	return tr.po.Get(str, vars...)
 }
 
 func (tr *reentrantTranslator) GetN(str, plural string, n int, vars ...any) string {
+	tr.record("GetN")
 	tr.mutateLocale()
 	return tr.po.GetN(str, plural, n, vars...)
 }
 
 func (tr *reentrantTranslator) GetC(str, ctx string, vars ...any) string {
+	tr.record("GetC")
 	tr.mutateLocale()
 	return tr.po.GetC(str, ctx, vars...)
 }
 
 func (tr *reentrantTranslator) GetNC(str, plural string, n int, ctx string, vars ...any) string {
+	tr.record("GetNC")
 	tr.mutateLocale()
 	return tr.po.GetNC(str, plural, n, ctx, vars...)
 }
 
 func (tr *reentrantTranslator) MarshalBinary() ([]byte, error) {
+	tr.record("MarshalBinary")
 	tr.mutateLocale()
 	if tr.marshalErr != nil {
 		return nil, tr.marshalErr
 	}
 	return tr.po.MarshalBinary()
 }
-
 func (tr *reentrantTranslator) UnmarshalBinary(data []byte) error {
+	tr.record("UnmarshalBinary")
 	return tr.po.UnmarshalBinary(data)
 }
 
 func (tr *reentrantTranslator) GetDomain() *Domain {
+	tr.record("GetDomain")
 	tr.mutateLocale()
 	return tr.po.GetDomain()
 }
@@ -732,50 +764,55 @@ func TestArabicMissingPluralForm(t *testing.T) {
 }
 
 func TestLocaleBinaryEncoding(t *testing.T) {
-	var locales []*Locale
-	{ // test os
-		// Create Locale
-		locales = append(locales, NewLocale("fixtures/", "en_US"))
+	const pluralForms = "nplurals=2; plural=(n != 1);"
+	data := encodeTestGob(t, &LocaleEncoding{
+		Path:          "fixtures/",
+		Lang:          "en_US",
+		DefaultDomain: "default",
+		Domains: map[string][]byte{
+			"default": encodeTestGob(t, &TranslatorEncoding{
+				Language:    "en_US",
+				PluralForms: pluralForms,
+				Nplurals:    2,
+				Plural:      "(n != 1)",
+				Translations: map[string]*Translation{
+					"My text": {
+						ID:  "My text",
+						Trs: map[int]string{0: "Translated text"},
+					},
+					"More": {
+						ID:  "More",
+						Trs: map[int]string{0: "More translation"},
+					},
+					"One with var: %s": {
+						ID:       "One with var: %s",
+						PluralID: "Several with vars: %s",
+						Trs:      map[int]string{0: "This one is the singular: %s", 1: "This one is the plural: %s"},
+					},
+				},
+			}),
+		},
+	})
+
+	locale := new(Locale)
+	if err := locale.UnmarshalBinary(data); err != nil {
+		t.Fatal(err)
 	}
-	{ // test fs
-		locales = append(locales, NewLocaleFS("en_US", os.DirFS("fixtures")))
+
+	if got := locale.GetLanguage(); got != "en_US" {
+		t.Errorf("decoded language = %q, want %q", got, "en_US")
 	}
-
-	for _, l := range locales {
-		l.AddDomain("default")
-
-		buff, err := l.MarshalBinary()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		l2 := new(Locale)
-		err = l2.UnmarshalBinary(buff)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Check object properties
-		if l.path != l2.path {
-			t.Fatalf("path doesn't match: '%s' vs '%s'", l.path, l2.path)
-		}
-		if l.lang != l2.lang {
-			t.Fatalf("lang doesn't match: '%s' vs '%s'", l.lang, l2.lang)
-		}
-		if l.defaultDomain != l2.defaultDomain {
-			t.Fatalf("defaultDomain doesn't match: '%s' vs '%s'", l.defaultDomain, l2.defaultDomain)
-		}
-
-		// Check translations
-		if l.Get("My text") != l2.Get("My text") {
-			t.Errorf("'%s' is different from '%s", l.Get("My text"), l2.Get("My text"))
-		}
-		if l.Get("More") != l2.Get("More") {
-			t.Errorf("'%s' is different from '%s", l.Get("More"), l2.Get("More"))
-		}
-		if l.GetN("One with var: %s", "Several with vars: %s", 3, "VALUE") != l2.GetN("One with var: %s", "Several with vars: %s", 3, "VALUE") {
-			t.Errorf("'%s' is different from '%s", l.GetN("One with var: %s", "Several with vars: %s", 3, "VALUE"), l2.GetN("One with var: %s", "Several with vars: %s", 3, "VALUE"))
-		}
+	if got := locale.GetDomain(); got != "default" {
+		t.Errorf("decoded default domain = %q, want %q", got, "default")
+	}
+	if got := locale.Get("My text"); got != "Translated text" {
+		t.Errorf("decoded My text = %q, want %q", got, "Translated text")
+	}
+	if got := locale.Get("More"); got != "More translation" {
+		t.Errorf("decoded More = %q, want %q", got, "More translation")
+	}
+	if got := locale.GetN("One with var: %s", "Several with vars: %s", 3, "VALUE"); got != "This one is the plural: VALUE" {
+		t.Errorf("decoded plural = %q, want %q", got, "This one is the plural: VALUE")
 	}
 }
 
@@ -808,8 +845,12 @@ func TestLocale_GetTranslations(t *testing.T) {
 		if !ok {
 			t.Error("missing expected translation")
 		}
-		if more.Get() != l.Get(moreMsgID) {
-			t.Errorf("translations of msgid %s do not match: \"%s\" != \"%s\"", moreMsgID, more.Get(), l.Get(moreMsgID))
+		if got := more.Get(); got != "More translation" {
+			t.Errorf("translations of msgid %s = %q, want %q", moreMsgID, got, "More translation")
+		}
+		more.Set("caller mutation")
+		if got := l.Get(moreMsgID); got != "More translation" {
+			t.Errorf("mutating GetTranslations result changed Locale: got %q", got)
 		}
 	}
 }
@@ -867,36 +908,31 @@ func TestLocaleTranslatorCallsReleaseLock(t *testing.T) {
 	locale.AddTranslator("default", translator)
 
 	calls := []struct {
-		name string
-		call func()
+		name           string
+		translatorCall string
+		call           func()
 	}{
-		{name: "Get", call: func() { _ = locale.Get("message") }},
-		{name: "GetN", call: func() { _ = locale.GetN("message", "messages", 2) }},
-		{name: "GetC", call: func() { _ = locale.GetC("message", "context") }},
-		{name: "GetNC", call: func() { _ = locale.GetNC("message", "messages", 2, "context") }},
-		{name: "GetD", call: func() { _ = locale.GetD("default", "message") }},
-		{name: "GetND", call: func() { _ = locale.GetND("default", "message", "messages", 2) }},
-		{name: "GetDC", call: func() { _ = locale.GetDC("default", "message", "context") }},
-		{name: "GetNDC", call: func() { _ = locale.GetNDC("default", "message", "messages", 2, "context") }},
-		{name: "IsTranslatedND", call: func() { _ = locale.IsTranslatedND("default", "message", 0) }},
-		{name: "IsTranslatedNDC", call: func() { _ = locale.IsTranslatedNDC("default", "message", 0, "context") }},
-		{name: "GetTranslations", call: func() { _ = locale.GetTranslations() }},
-		{name: "MarshalBinary", call: func() { _, _ = locale.MarshalBinary() }},
+		{name: "Get", translatorCall: "Get", call: func() { _ = locale.Get("message") }},
+		{name: "GetN", translatorCall: "GetN", call: func() { _ = locale.GetN("message", "messages", 2) }},
+		{name: "GetC", translatorCall: "GetC", call: func() { _ = locale.GetC("message", "context") }},
+		{name: "GetNC", translatorCall: "GetNC", call: func() { _ = locale.GetNC("message", "messages", 2, "context") }},
+		{name: "GetD", translatorCall: "Get", call: func() { _ = locale.GetD("default", "message") }},
+		{name: "GetND", translatorCall: "GetN", call: func() { _ = locale.GetND("default", "message", "messages", 2) }},
+		{name: "GetDC", translatorCall: "GetC", call: func() { _ = locale.GetDC("default", "message", "context") }},
+		{name: "GetNDC", translatorCall: "GetNC", call: func() { _ = locale.GetNDC("default", "message", "messages", 2, "context") }},
+		{name: "IsTranslatedND", translatorCall: "GetDomain", call: func() { _ = locale.IsTranslatedND("default", "message", 0) }},
+		{name: "IsTranslatedNDC", translatorCall: "GetDomain", call: func() { _ = locale.IsTranslatedNDC("default", "message", 0, "context") }},
+		{name: "GetTranslations", translatorCall: "GetDomain", call: func() { _ = locale.GetTranslations() }},
+		{name: "MarshalBinary", translatorCall: "MarshalBinary", call: func() { _, _ = locale.MarshalBinary() }},
 	}
 
 	for _, tt := range calls {
 		t.Run(tt.name, func(t *testing.T) {
 			locale.SetDomain("default")
-			done := make(chan struct{})
-			go func() {
-				tt.call()
-				close(done)
-			}()
-
-			select {
-			case <-done:
-			case <-time.After(time.Second):
-				t.Fatal("Locale call deadlocked while translator mutated its Locale")
+			before := translator.calls[tt.translatorCall]
+			waitForLocaleCall(t, tt.call)
+			if got := translator.calls[tt.translatorCall]; got != before+1 {
+				t.Fatalf("%s did not invoke translator.%s exactly once: count %d -> %d", tt.name, tt.translatorCall, before, got)
 			}
 		})
 	}
@@ -913,8 +949,12 @@ func TestLocaleMarshalBinaryPropagatesTranslatorError(t *testing.T) {
 	translator.marshalErr = sentinel
 	locale.AddTranslator("default", translator)
 
-	if _, err := locale.MarshalBinary(); !errors.Is(err, sentinel) {
-		t.Fatalf("MarshalBinary error = %v, want sentinel %v", err, sentinel)
+	var gotErr error
+	waitForLocaleCall(t, func() {
+		_, gotErr = locale.MarshalBinary()
+	})
+	if !errors.Is(gotErr, sentinel) {
+		t.Fatalf("MarshalBinary error = %v, want sentinel %v", gotErr, sentinel)
 	}
 }
 func TestLocaleNilTranslatorIsSafe(t *testing.T) {
@@ -954,116 +994,75 @@ func TestLocaleBinaryEncodingRestoresPluralForms(t *testing.T) {
 		pluralRule = "(n==1) ? 0 : (n==2) ? 1 : 2"
 	)
 
-	po := NewPo()
-	po.Parse([]byte(`
-msgid ""
-msgstr ""
-"Language: xx\n"
-"Plural-Forms: nplurals=3; plural=` + pluralRule + `;\n"
-
-msgid "` + msgID + `"
-msgid_plural "` + msgPlural + `"
-msgstr[0] "one apple"
-msgstr[1] "two apples"
-msgstr[2] "many apples"
-`))
-
-	locale := NewLocale("", "xx")
-	locale.AddTranslator("default", po)
-
-	data, err := locale.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
+	data := encodeTestGob(t, &LocaleEncoding{
+		Lang:          "xx",
+		DefaultDomain: "default",
+		Domains: map[string][]byte{
+			"default": encodeTestGob(t, &TranslatorEncoding{
+				Language:    "xx",
+				PluralForms: "nplurals=3; plural=" + pluralRule + ";",
+				Nplurals:    3,
+				Plural:      pluralRule,
+				Translations: map[string]*Translation{
+					msgID: {
+						ID:       msgID,
+						PluralID: msgPlural,
+						Trs:      map[int]string{0: "one apple", 1: "two apples", 2: "many apples"},
+					},
+				},
+			}),
+		},
+	})
 
 	restored := new(Locale)
 	if err := restored.UnmarshalBinary(data); err != nil {
 		t.Fatal(err)
 	}
 
-	translator, ok := restored.Domains["default"]
-	if !ok {
-		t.Fatal("decoded locale is missing the default translator")
+	if got := restored.GetLanguage(); got != "xx" {
+		t.Errorf("decoded language = %q, want %q", got, "xx")
 	}
-	recoveredPo, ok := translator.(*Po)
-	if !ok {
-		t.Fatalf("decoded translator has type %T, want *Po", translator)
+	if got := restored.GetN(msgID, msgPlural, 1); got != "one apple" {
+		t.Errorf("GetN(1) = %q, want %q", got, "one apple")
 	}
-
-	domain := recoveredPo.GetDomain()
-	if !reflect.DeepEqual(recoveredPo.Headers, domain.Headers) {
-		t.Errorf("public Headers differ from the recovered domain: %#v vs %#v", recoveredPo.Headers, domain.Headers)
+	if got := restored.GetN(msgID, msgPlural, 2); got != "two apples" {
+		t.Errorf("GetN(2) = %q, want %q", got, "two apples")
 	}
-	if recoveredPo.Language != domain.Language {
-		t.Errorf("public Language differs from the recovered domain: %q vs %q", recoveredPo.Language, domain.Language)
-	}
-	if recoveredPo.PluralForms != domain.PluralForms {
-		t.Errorf("public PluralForms differs from the recovered domain: %q vs %q", recoveredPo.PluralForms, domain.PluralForms)
-	}
-	if !reflect.DeepEqual(recoveredPo.Headers, po.Headers) {
-		t.Errorf("decoded public Headers differ from the source: %#v vs %#v", recoveredPo.Headers, po.Headers)
-	}
-	if recoveredPo.Language != po.Language {
-		t.Errorf("decoded public Language differs from the source: %q vs %q", recoveredPo.Language, po.Language)
-	}
-	if recoveredPo.PluralForms != po.PluralForms {
-		t.Errorf("decoded public PluralForms differs from the source: %q vs %q", recoveredPo.PluralForms, po.PluralForms)
-	}
-
-	tests := []struct {
-		n    int
-		want string
-	}{
-		{n: 1, want: "one apple"},
-		{n: 2, want: "two apples"},
-		{n: 5, want: "many apples"},
-	}
-	for _, tt := range tests {
-		if got := recoveredPo.GetN(msgID, msgPlural, tt.n); got != tt.want {
-			t.Errorf("GetN(%d) = %q, want %q", tt.n, got, tt.want)
-		}
+	if got := restored.GetN(msgID, msgPlural, 5); got != "many apples" {
+		t.Errorf("GetN(5) = %q, want %q", got, "many apples")
 	}
 }
 
 func TestLocaleBinaryEncodingInvalidPluralFallback(t *testing.T) {
-	po := NewPo()
-	po.Parse([]byte(`
-msgid ""
-msgstr ""
-"Plural-Forms: nplurals=3; plural=invalid;\n"
-
-msgid "One apple"
-msgid_plural "Many apples"
-msgstr[0] "one apple"
-msgstr[1] "many apples"
-`))
-
-	locale := NewLocale("", "xx")
-	locale.AddTranslator("default", po)
-
-	data, err := locale.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
+	data := encodeTestGob(t, &LocaleEncoding{
+		Lang:          "xx",
+		DefaultDomain: "default",
+		Domains: map[string][]byte{
+			"default": encodeTestGob(t, &TranslatorEncoding{
+				Language:    "xx",
+				PluralForms: "nplurals=3; plural=invalid;",
+				Nplurals:    3,
+				Plural:      "invalid",
+				Translations: map[string]*Translation{
+					"One apple": {
+						ID:       "One apple",
+						PluralID: "Many apples",
+						Trs:      map[int]string{0: "one apple", 1: "many apples"},
+					},
+				},
+			}),
+		},
+	})
 
 	restored := new(Locale)
 	if err := restored.UnmarshalBinary(data); err != nil {
 		t.Fatal(err)
 	}
 
-	translator, ok := restored.Domains["default"]
-	if !ok {
-		t.Fatal("decoded locale is missing the default translator")
-	}
-	recoveredPo, ok := translator.(*Po)
-	if !ok {
-		t.Fatalf("decoded translator has type %T, want *Po", translator)
-	}
-
-	if got := recoveredPo.GetN("One apple", "Many apples", 1); got != "one apple" {
+	if got := restored.GetN("One apple", "Many apples", 1); got != "one apple" {
 		t.Errorf("invalid plural rule GetN(1) = %q, want %q", got, "one apple")
 	}
-	if got := recoveredPo.GetN("One apple", "Many apples", 2); got != "many apples" {
+	if got := restored.GetN("One apple", "Many apples", 2); got != "many apples" {
 		t.Errorf("invalid plural rule GetN(2) = %q, want %q", got, "many apples")
 	}
 }
@@ -1309,12 +1308,14 @@ func TestLocaleBinaryEncodingRace(t *testing.T) {
 	wg.Wait()
 }
 func FuzzDomainUnmarshalBinaryAtomicAndUsable(f *testing.F) {
-	seed := NewDomain()
-	seed.Set("seed", "value")
-	valid, err := seed.MarshalBinary()
-	if err != nil {
-		f.Fatalf("MarshalBinary seed: %v", err)
-	}
+	valid := encodeTestGob(f, &TranslatorEncoding{
+		Translations: map[string]*Translation{
+			"seed": {
+				ID:  "seed",
+				Trs: map[int]string{0: "value"},
+			},
+		},
+	})
 	f.Add(valid)
 	f.Add([]byte("not gob"))
 	f.Add([]byte{})
@@ -1363,12 +1364,21 @@ func FuzzDomainUnmarshalBinaryAtomicAndUsable(f *testing.F) {
 }
 
 func FuzzLocaleUnmarshalBinaryAtomicAndUsable(f *testing.F) {
-	seed := NewLocale("", "en")
-	seed.AddTranslator("default", NewPo())
-	valid, err := seed.MarshalBinary()
-	if err != nil {
-		f.Fatalf("MarshalBinary seed: %v", err)
-	}
+	valid := encodeTestGob(f, &LocaleEncoding{
+		Path:          "seed/path",
+		Lang:          "en",
+		DefaultDomain: "default",
+		Domains: map[string][]byte{
+			"default": encodeTestGob(f, &TranslatorEncoding{
+				Translations: map[string]*Translation{
+					"seed": {
+						ID:  "seed",
+						Trs: map[int]string{0: "value"},
+					},
+				},
+			}),
+		},
+	})
 	f.Add(valid)
 	f.Add([]byte("not gob"))
 	f.Add([]byte{})

--- a/locale_test.go
+++ b/locale_test.go
@@ -9,13 +9,78 @@ import (
 	"bytes"
 	"embed"
 	"encoding/gob"
+	"errors"
 	"os"
 	"path"
 	"reflect"
 	"sync"
 	"testing"
 	"testing/fstest"
+	"time"
 )
+
+type reentrantTranslator struct {
+	locale     *Locale
+	po         *Po
+	marshalErr error
+}
+
+func newReentrantTranslator(locale *Locale) *reentrantTranslator {
+	po := NewPo()
+	po.Set("message", "translated")
+	return &reentrantTranslator{locale: locale, po: po}
+}
+
+func (tr *reentrantTranslator) mutateLocale() {
+	if tr.locale != nil {
+		tr.locale.SetDomain("reentrant")
+	}
+}
+
+func (tr *reentrantTranslator) ParseFile(f string) {
+	tr.po.ParseFile(f)
+}
+
+func (tr *reentrantTranslator) Parse(data []byte) {
+	tr.po.Parse(data)
+}
+
+func (tr *reentrantTranslator) Get(str string, vars ...any) string {
+	tr.mutateLocale()
+	return tr.po.Get(str, vars...)
+}
+
+func (tr *reentrantTranslator) GetN(str, plural string, n int, vars ...any) string {
+	tr.mutateLocale()
+	return tr.po.GetN(str, plural, n, vars...)
+}
+
+func (tr *reentrantTranslator) GetC(str, ctx string, vars ...any) string {
+	tr.mutateLocale()
+	return tr.po.GetC(str, ctx, vars...)
+}
+
+func (tr *reentrantTranslator) GetNC(str, plural string, n int, ctx string, vars ...any) string {
+	tr.mutateLocale()
+	return tr.po.GetNC(str, plural, n, ctx, vars...)
+}
+
+func (tr *reentrantTranslator) MarshalBinary() ([]byte, error) {
+	tr.mutateLocale()
+	if tr.marshalErr != nil {
+		return nil, tr.marshalErr
+	}
+	return tr.po.MarshalBinary()
+}
+
+func (tr *reentrantTranslator) UnmarshalBinary(data []byte) error {
+	return tr.po.UnmarshalBinary(data)
+}
+
+func (tr *reentrantTranslator) GetDomain() *Domain {
+	tr.mutateLocale()
+	return tr.po.GetDomain()
+}
 
 func TestLocale(t *testing.T) {
 	// Set PO content
@@ -796,6 +861,91 @@ func TestLocale_MissingIsTranslatedWrappers(t *testing.T) {
 		t.Error("Expected false for missing domain")
 	}
 }
+func TestLocaleTranslatorCallsReleaseLock(t *testing.T) {
+	locale := NewLocale("", "en")
+	translator := newReentrantTranslator(locale)
+	locale.AddTranslator("default", translator)
+
+	calls := []struct {
+		name string
+		call func()
+	}{
+		{name: "Get", call: func() { _ = locale.Get("message") }},
+		{name: "GetN", call: func() { _ = locale.GetN("message", "messages", 2) }},
+		{name: "GetC", call: func() { _ = locale.GetC("message", "context") }},
+		{name: "GetNC", call: func() { _ = locale.GetNC("message", "messages", 2, "context") }},
+		{name: "GetD", call: func() { _ = locale.GetD("default", "message") }},
+		{name: "GetND", call: func() { _ = locale.GetND("default", "message", "messages", 2) }},
+		{name: "GetDC", call: func() { _ = locale.GetDC("default", "message", "context") }},
+		{name: "GetNDC", call: func() { _ = locale.GetNDC("default", "message", "messages", 2, "context") }},
+		{name: "IsTranslatedND", call: func() { _ = locale.IsTranslatedND("default", "message", 0) }},
+		{name: "IsTranslatedNDC", call: func() { _ = locale.IsTranslatedNDC("default", "message", 0, "context") }},
+		{name: "GetTranslations", call: func() { _ = locale.GetTranslations() }},
+		{name: "MarshalBinary", call: func() { _, _ = locale.MarshalBinary() }},
+	}
+
+	for _, tt := range calls {
+		t.Run(tt.name, func(t *testing.T) {
+			locale.SetDomain("default")
+			done := make(chan struct{})
+			go func() {
+				tt.call()
+				close(done)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("Locale call deadlocked while translator mutated its Locale")
+			}
+		})
+	}
+
+	if got := locale.GetDomain(); got != "reentrant" {
+		t.Errorf("reentrant translator did not mutate Locale: got domain %q", got)
+	}
+}
+
+func TestLocaleMarshalBinaryPropagatesTranslatorError(t *testing.T) {
+	sentinel := errors.New("sentinel marshal error")
+	locale := NewLocale("", "en")
+	translator := newReentrantTranslator(locale)
+	translator.marshalErr = sentinel
+	locale.AddTranslator("default", translator)
+
+	if _, err := locale.MarshalBinary(); !errors.Is(err, sentinel) {
+		t.Fatalf("MarshalBinary error = %v, want sentinel %v", err, sentinel)
+	}
+}
+func TestLocaleNilTranslatorIsSafe(t *testing.T) {
+	locale := NewLocale("", "en")
+	locale.AddTranslator("nil", nil)
+
+	if got := locale.GetD("nil", "source"); got != "source" {
+		t.Errorf("GetD with nil translator = %q, want %q", got, "source")
+	}
+	if got := locale.GetND("nil", "one", "many", 2); got != "many" {
+		t.Errorf("GetND with nil translator = %q, want %q", got, "many")
+	}
+	if got := locale.GetDC("nil", "source", "context"); got != "source" {
+		t.Errorf("GetDC with nil translator = %q, want %q", got, "source")
+	}
+	if got := locale.GetNDC("nil", "one", "many", 2, "context"); got != "many" {
+		t.Errorf("GetNDC with nil translator = %q, want %q", got, "many")
+	}
+	if locale.IsTranslatedND("nil", "source", 0) {
+		t.Error("IsTranslatedND with nil translator should be false")
+	}
+	if locale.IsTranslatedNDC("nil", "source", 0, "context") {
+		t.Error("IsTranslatedNDC with nil translator should be false")
+	}
+	if got := locale.GetTranslations(); got == nil {
+		t.Error("GetTranslations with nil translator returned nil")
+	}
+	if _, err := locale.MarshalBinary(); err != nil {
+		t.Fatalf("MarshalBinary with nil translator failed: %v", err)
+	}
+}
 
 func TestLocaleBinaryEncodingRestoresPluralForms(t *testing.T) {
 	const (
@@ -1020,6 +1170,50 @@ msgstr "parsed translation"
 		})
 	}
 }
+func TestTranslatorEncodingNormalizesNilEntries(t *testing.T) {
+	ordinary := map[string]*Translation{
+		"ordinary": nil,
+	}
+	contexts := map[string]map[string]*Translation{
+		"nil-context": nil,
+		"context": {
+			"contextual": nil,
+		},
+	}
+	encoding := &TranslatorEncoding{
+		Translations: ordinary,
+		Contexts:     contexts,
+	}
+
+	po, ok := encoding.GetTranslator().(*Po)
+	if !ok {
+		t.Fatalf("GetTranslator() returned %T, want *Po", encoding.GetTranslator())
+	}
+
+	if ordinary["ordinary"] == nil {
+		t.Fatal("ordinary nil entry was not normalized in the caller-owned map")
+	}
+	if got := po.Get("ordinary"); got != "ordinary" {
+		t.Errorf("normalized ordinary entry = %q, want %q", got, "ordinary")
+	}
+	if contexts["nil-context"] == nil {
+		t.Fatal("nil context map was not normalized in the caller-owned map")
+	}
+	if contexts["context"]["contextual"] == nil {
+		t.Fatal("nil contextual entry was not normalized in the caller-owned map")
+	}
+	if got := po.GetC("contextual", "context"); got != "contextual" {
+		t.Errorf("normalized contextual entry = %q, want %q", got, "contextual")
+	}
+
+	transferred := NewTranslation()
+	transferred.ID = "transferred"
+	transferred.Set("transferred value")
+	ordinary["transferred"] = transferred
+	if got := po.Get("transferred"); got != "transferred value" {
+		t.Errorf("non-nil translation map was not transferred by ownership: got %q", got)
+	}
+}
 
 func TestLocaleBinaryEncodingKeepsStateOnDomainDecodeError(t *testing.T) {
 	filesystem := fstest.MapFS{}
@@ -1113,4 +1307,119 @@ func TestLocaleBinaryEncodingRace(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+func FuzzDomainUnmarshalBinaryAtomicAndUsable(f *testing.F) {
+	seed := NewDomain()
+	seed.Set("seed", "value")
+	valid, err := seed.MarshalBinary()
+	if err != nil {
+		f.Fatalf("MarshalBinary seed: %v", err)
+	}
+	f.Add(valid)
+	f.Add([]byte("not gob"))
+	f.Add([]byte{})
+	f.Add([]byte{0, 1, 2, 3})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 64<<10 {
+			return
+		}
+
+		domain := NewDomain()
+		domain.Set("sentinel", "before")
+
+		var unmarshalErr error
+		panicked := false
+		func() {
+			defer func() {
+				if recover() != nil {
+					panicked = true
+				}
+			}()
+			unmarshalErr = domain.UnmarshalBinary(data)
+		}()
+		if panicked {
+			t.Fatal("UnmarshalBinary panicked")
+		}
+
+		if unmarshalErr != nil {
+			if got := domain.Get("sentinel"); got != "before" {
+				t.Fatalf("failed decode changed existing state: got %q, want %q", got, "before")
+			}
+			return
+		}
+
+		if domain.GetTranslations() == nil {
+			t.Fatal("successful decode left ordinary translations unusable")
+		}
+		if domain.GetCtxTranslations() == nil {
+			t.Fatal("successful decode left contextual translations unusable")
+		}
+		_ = domain.Get("sentinel")
+		_ = domain.GetN("sentinel", "sentinels", 2)
+		_ = domain.GetC("sentinel", "context")
+		_ = domain.GetNC("sentinel", "sentinels", 2, "context")
+	})
+}
+
+func FuzzLocaleUnmarshalBinaryAtomicAndUsable(f *testing.F) {
+	seed := NewLocale("", "en")
+	seed.AddTranslator("default", NewPo())
+	valid, err := seed.MarshalBinary()
+	if err != nil {
+		f.Fatalf("MarshalBinary seed: %v", err)
+	}
+	f.Add(valid)
+	f.Add([]byte("not gob"))
+	f.Add([]byte{})
+	f.Add([]byte{0, 1, 2, 3})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 64<<10 {
+			return
+		}
+
+		locale := NewLocaleFSWithPath("old", fstest.MapFS{}, "old/path")
+		oldTranslator := NewPo()
+		oldTranslator.Set("sentinel", "before")
+		locale.AddTranslator("old", oldTranslator)
+		locale.SetDomain("old")
+
+		var unmarshalErr error
+		panicked := false
+		func() {
+			defer func() {
+				if recover() != nil {
+					panicked = true
+				}
+			}()
+			unmarshalErr = locale.UnmarshalBinary(data)
+		}()
+		if panicked {
+			t.Fatal("UnmarshalBinary panicked")
+		}
+
+		if unmarshalErr != nil {
+			if locale.path != "old/path" || locale.GetLanguage() != "old" || locale.GetDomain() != "old" {
+				t.Fatal("failed decode changed locale configuration")
+			}
+			if locale.fs == nil {
+				t.Fatal("failed decode cleared the filesystem")
+			}
+			if got, ok := locale.Domains["old"]; !ok || got != oldTranslator {
+				t.Fatal("failed decode changed existing domains")
+			}
+			return
+		}
+
+		if locale.GetTranslations() == nil {
+			t.Fatal("successful decode left locale translations unusable")
+		}
+		_ = locale.GetDomain()
+		_ = locale.GetLanguage()
+		_ = locale.Get("sentinel")
+		_ = locale.GetN("sentinel", "sentinels", 2)
+		_ = locale.GetC("sentinel", "context")
+		_ = locale.GetNC("sentinel", "sentinels", 2, "context")
+	})
 }

--- a/locale_test.go
+++ b/locale_test.go
@@ -10,8 +10,10 @@ import (
 	"embed"
 	"encoding/gob"
 	"errors"
+	"maps"
 	"os"
 	"path"
+	"reflect"
 	"sync"
 	"testing"
 	"testing/fstest"
@@ -1307,6 +1309,82 @@ func TestLocaleBinaryEncodingRace(t *testing.T) {
 
 	wg.Wait()
 }
+
+type fuzzDomainSnapshot struct {
+	headers             HeaderMap
+	language            string
+	pluralForms         string
+	nplurals            int
+	plural              string
+	headerComments      []string
+	translations        map[string]*Translation
+	contextTranslations map[string]map[string]*Translation
+}
+
+func seedFuzzDomain(domain *Domain) {
+	domain.Headers = HeaderMap{
+		"Language":     []string{"seed-language"},
+		"Plural-Forms": []string{"nplurals=2; plural=(n != 1);"},
+		"X-Seed":       []string{"first", "second"},
+	}
+	domain.Language = "seed-language"
+	domain.PluralForms = "nplurals=2; plural=(n != 1);"
+	domain.nplurals = 2
+	domain.plural = "(n != 1)"
+	domain.headerComments = []string{"# seeded comment"}
+
+	domain.Set("sentinel", "before")
+	domain.SetRefs("sentinel", []string{"seed.go:1", "seed.go:2"})
+	domain.SetN("plural", "plurals", 2, "plural before")
+	domain.Set("plural", "singular before")
+	domain.SetNC("contextual", "contextual plurals", "context", 2, "context plural before")
+	domain.SetC("contextual", "context", "context before")
+}
+
+func snapshotFuzzDomain(domain *Domain) fuzzDomainSnapshot {
+	return fuzzDomainSnapshot{
+		headers:             cloneHeaderMap(domain.Headers),
+		language:            domain.Language,
+		pluralForms:         domain.PluralForms,
+		nplurals:            domain.nplurals,
+		plural:              domain.plural,
+		headerComments:      append([]string(nil), domain.headerComments...),
+		translations:        domain.GetTranslations(),
+		contextTranslations: domain.GetCtxTranslations(),
+	}
+}
+
+type fuzzLocaleSnapshot struct {
+	path                  string
+	language              string
+	defaultDomain         string
+	filesystem            *fstest.MapFS
+	domains               map[string]Translator
+	translatorHeaders     HeaderMap
+	translatorLanguage    string
+	translatorPluralForms string
+	domain                fuzzDomainSnapshot
+}
+
+func snapshotFuzzLocale(locale *Locale, translator *Po) fuzzLocaleSnapshot {
+	var filesystem *fstest.MapFS
+	if locale.fs != nil {
+		filesystem, _ = locale.fs.(*fstest.MapFS)
+	}
+
+	return fuzzLocaleSnapshot{
+		path:                  locale.path,
+		language:              locale.GetLanguage(),
+		defaultDomain:         locale.GetDomain(),
+		filesystem:            filesystem,
+		domains:               maps.Clone(locale.Domains),
+		translatorHeaders:     cloneHeaderMap(translator.Headers),
+		translatorLanguage:    translator.Language,
+		translatorPluralForms: translator.PluralForms,
+		domain:                snapshotFuzzDomain(translator.GetDomain()),
+	}
+}
+
 func FuzzDomainUnmarshalBinaryAtomicAndUsable(f *testing.F) {
 	valid := encodeTestGob(f, &TranslatorEncoding{
 		Translations: map[string]*Translation{
@@ -1327,7 +1405,8 @@ func FuzzDomainUnmarshalBinaryAtomicAndUsable(f *testing.F) {
 		}
 
 		domain := NewDomain()
-		domain.Set("sentinel", "before")
+		seedFuzzDomain(domain)
+		before := snapshotFuzzDomain(domain)
 
 		var unmarshalErr error
 		panicked := false
@@ -1344,8 +1423,9 @@ func FuzzDomainUnmarshalBinaryAtomicAndUsable(f *testing.F) {
 		}
 
 		if unmarshalErr != nil {
-			if got := domain.Get("sentinel"); got != "before" {
-				t.Fatalf("failed decode changed existing state: got %q, want %q", got, "before")
+			after := snapshotFuzzDomain(domain)
+			if !reflect.DeepEqual(before, after) {
+				t.Fatalf("failed decode changed domain state: got %#v, want %#v", after, before)
 			}
 			return
 		}
@@ -1389,11 +1469,16 @@ func FuzzLocaleUnmarshalBinaryAtomicAndUsable(f *testing.F) {
 			return
 		}
 
-		locale := NewLocaleFSWithPath("old", fstest.MapFS{}, "old/path")
+		filesystem := &fstest.MapFS{}
+		locale := NewLocaleFSWithPath("old", filesystem, "old/path")
 		oldTranslator := NewPo()
-		oldTranslator.Set("sentinel", "before")
+		seedFuzzDomain(oldTranslator.GetDomain())
+		oldTranslator.Headers = cloneHeaderMap(oldTranslator.GetDomain().Headers)
+		oldTranslator.Language = oldTranslator.GetDomain().Language
+		oldTranslator.PluralForms = oldTranslator.GetDomain().PluralForms
 		locale.AddTranslator("old", oldTranslator)
 		locale.SetDomain("old")
+		before := snapshotFuzzLocale(locale, oldTranslator)
 
 		var unmarshalErr error
 		panicked := false
@@ -1410,14 +1495,9 @@ func FuzzLocaleUnmarshalBinaryAtomicAndUsable(f *testing.F) {
 		}
 
 		if unmarshalErr != nil {
-			if locale.path != "old/path" || locale.GetLanguage() != "old" || locale.GetDomain() != "old" {
-				t.Fatal("failed decode changed locale configuration")
-			}
-			if locale.fs == nil {
-				t.Fatal("failed decode cleared the filesystem")
-			}
-			if got, ok := locale.Domains["old"]; !ok || got != oldTranslator {
-				t.Fatal("failed decode changed existing domains")
+			after := snapshotFuzzLocale(locale, oldTranslator)
+			if !reflect.DeepEqual(before, after) {
+				t.Fatalf("failed decode changed locale state: got %#v, want %#v", after, before)
 			}
 			return
 		}

--- a/locale_test.go
+++ b/locale_test.go
@@ -6,9 +6,13 @@
 package gotext
 
 import (
+	"bytes"
 	"embed"
+	"encoding/gob"
 	"os"
 	"path"
+	"reflect"
+	"sync"
 	"testing"
 	"testing/fstest"
 )
@@ -791,4 +795,322 @@ func TestLocale_MissingIsTranslatedWrappers(t *testing.T) {
 	if l.IsTranslatedNC("test", 1, "ctx") {
 		t.Error("Expected false for missing domain")
 	}
+}
+
+func TestLocaleBinaryEncodingRestoresPluralForms(t *testing.T) {
+	const (
+		msgID      = "One apple"
+		msgPlural  = "Many apples"
+		pluralRule = "(n==1) ? 0 : (n==2) ? 1 : 2"
+	)
+
+	po := NewPo()
+	po.Parse([]byte(`
+msgid ""
+msgstr ""
+"Language: xx\n"
+"Plural-Forms: nplurals=3; plural=` + pluralRule + `;\n"
+
+msgid "` + msgID + `"
+msgid_plural "` + msgPlural + `"
+msgstr[0] "one apple"
+msgstr[1] "two apples"
+msgstr[2] "many apples"
+`))
+
+	locale := NewLocale("", "xx")
+	locale.AddTranslator("default", po)
+
+	data, err := locale.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	restored := new(Locale)
+	if err := restored.UnmarshalBinary(data); err != nil {
+		t.Fatal(err)
+	}
+
+	translator, ok := restored.Domains["default"]
+	if !ok {
+		t.Fatal("decoded locale is missing the default translator")
+	}
+	recoveredPo, ok := translator.(*Po)
+	if !ok {
+		t.Fatalf("decoded translator has type %T, want *Po", translator)
+	}
+
+	domain := recoveredPo.GetDomain()
+	if !reflect.DeepEqual(recoveredPo.Headers, domain.Headers) {
+		t.Errorf("public Headers differ from the recovered domain: %#v vs %#v", recoveredPo.Headers, domain.Headers)
+	}
+	if recoveredPo.Language != domain.Language {
+		t.Errorf("public Language differs from the recovered domain: %q vs %q", recoveredPo.Language, domain.Language)
+	}
+	if recoveredPo.PluralForms != domain.PluralForms {
+		t.Errorf("public PluralForms differs from the recovered domain: %q vs %q", recoveredPo.PluralForms, domain.PluralForms)
+	}
+	if !reflect.DeepEqual(recoveredPo.Headers, po.Headers) {
+		t.Errorf("decoded public Headers differ from the source: %#v vs %#v", recoveredPo.Headers, po.Headers)
+	}
+	if recoveredPo.Language != po.Language {
+		t.Errorf("decoded public Language differs from the source: %q vs %q", recoveredPo.Language, po.Language)
+	}
+	if recoveredPo.PluralForms != po.PluralForms {
+		t.Errorf("decoded public PluralForms differs from the source: %q vs %q", recoveredPo.PluralForms, po.PluralForms)
+	}
+
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{n: 1, want: "one apple"},
+		{n: 2, want: "two apples"},
+		{n: 5, want: "many apples"},
+	}
+	for _, tt := range tests {
+		if got := recoveredPo.GetN(msgID, msgPlural, tt.n); got != tt.want {
+			t.Errorf("GetN(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}
+
+func TestLocaleBinaryEncodingInvalidPluralFallback(t *testing.T) {
+	po := NewPo()
+	po.Parse([]byte(`
+msgid ""
+msgstr ""
+"Plural-Forms: nplurals=3; plural=invalid;\n"
+
+msgid "One apple"
+msgid_plural "Many apples"
+msgstr[0] "one apple"
+msgstr[1] "many apples"
+`))
+
+	locale := NewLocale("", "xx")
+	locale.AddTranslator("default", po)
+
+	data, err := locale.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	restored := new(Locale)
+	if err := restored.UnmarshalBinary(data); err != nil {
+		t.Fatal(err)
+	}
+
+	translator, ok := restored.Domains["default"]
+	if !ok {
+		t.Fatal("decoded locale is missing the default translator")
+	}
+	recoveredPo, ok := translator.(*Po)
+	if !ok {
+		t.Fatalf("decoded translator has type %T, want *Po", translator)
+	}
+
+	if got := recoveredPo.GetN("One apple", "Many apples", 1); got != "one apple" {
+		t.Errorf("invalid plural rule GetN(1) = %q, want %q", got, "one apple")
+	}
+	if got := recoveredPo.GetN("One apple", "Many apples", 2); got != "many apples" {
+		t.Errorf("invalid plural rule GetN(2) = %q, want %q", got, "many apples")
+	}
+}
+
+func TestTranslatorEncodingGetTranslatorInitializesStorage(t *testing.T) {
+	initialTranslation := NewTranslation()
+	initialTranslation.ID = "initial"
+	initialTranslation.Set("initial translation")
+
+	initialContextTranslation := NewTranslation()
+	initialContextTranslation.ID = "initial context"
+	initialContextTranslation.Set("initial context translation")
+
+	partial := TranslatorEncoding{
+		Headers: HeaderMap{
+			"X-Initial": {"initial header"},
+		},
+		Translations: map[string]*Translation{
+			"initial": initialTranslation,
+		},
+		Contexts: map[string]map[string]*Translation{
+			"initial-context": {
+				"initial context": initialContextTranslation,
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		encoding TranslatorEncoding
+	}{
+		{name: "zero", encoding: TranslatorEncoding{}},
+		{name: "partial", encoding: partial},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			po, ok := tt.encoding.GetTranslator().(*Po)
+			if !ok {
+				t.Fatalf("GetTranslator() returned %T, want *Po", tt.encoding.GetTranslator())
+			}
+
+			po.Set("set message", "set translation")
+			if got := po.Get("set message"); got != "set translation" {
+				t.Errorf("Get after Set = %q, want %q", got, "set translation")
+			}
+
+			po.SetC("set context message", "set-context", "set context translation")
+			if got := po.GetC("set context message", "set-context"); got != "set context translation" {
+				t.Errorf("GetC after SetC = %q, want %q", got, "set context translation")
+			}
+
+			po.Parse([]byte(`
+msgid ""
+msgstr ""
+"Language: xx\n"
+"X-Test: header value\n"
+
+msgid "parsed message"
+msgstr "parsed translation"
+`))
+
+			if got := po.Get("parsed message"); got != "parsed translation" {
+				t.Errorf("Get after Parse = %q, want %q", got, "parsed translation")
+			}
+			if got := po.Get("set message"); got != "set translation" {
+				t.Errorf("Get lost value set before Parse: %q", got)
+			}
+			if got := po.GetC("set context message", "set-context"); got != "set context translation" {
+				t.Errorf("GetC lost value set before Parse: %q", got)
+			}
+			if got := po.Headers.Get("Language"); got != "xx" {
+				t.Errorf("public header access = %q, want %q", got, "xx")
+			}
+			if got := po.GetDomain().Headers.Get("X-Test"); got != "header value" {
+				t.Errorf("domain header access = %q, want %q", got, "header value")
+			}
+			if po.Language != "xx" {
+				t.Errorf("public Language = %q, want %q", po.Language, "xx")
+			}
+
+			if tt.name != "partial" {
+				return
+			}
+
+			transferredTranslation := NewTranslation()
+			transferredTranslation.ID = "transferred"
+			transferredTranslation.Set("transferred translation")
+			tt.encoding.Headers["X-Transferred"] = []string{"transferred header"}
+			tt.encoding.Translations["transferred"] = transferredTranslation
+			tt.encoding.Contexts["transferred-context"] = map[string]*Translation{
+				"transferred context": transferredTranslation,
+			}
+
+			if got := po.Headers.Get("X-Transferred"); got != "transferred header" {
+				t.Errorf("public Headers did not retain map ownership: %q", got)
+			}
+			if got := po.Get("transferred"); got != "transferred translation" {
+				t.Errorf("Translations did not retain map ownership: %q", got)
+			}
+			if got := po.GetC("transferred context", "transferred-context"); got != "transferred translation" {
+				t.Errorf("Contexts did not retain map ownership: %q", got)
+			}
+		})
+	}
+}
+
+func TestLocaleBinaryEncodingKeepsStateOnDomainDecodeError(t *testing.T) {
+	filesystem := fstest.MapFS{}
+	locale := NewLocaleFSWithPath("old", filesystem, "old/path")
+	oldTranslator := NewPo()
+	locale.AddTranslator("old", oldTranslator)
+	locale.SetDomain("old")
+
+	var buff bytes.Buffer
+	encoder := gob.NewEncoder(&buff)
+	err := encoder.Encode(&LocaleEncoding{
+		Path:          "new/path",
+		Lang:          "new",
+		Domains:       map[string][]byte{"new": []byte("invalid")},
+		DefaultDomain: "new",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := locale.UnmarshalBinary(buff.Bytes()); err == nil {
+		t.Fatal("UnmarshalBinary returned nil for an invalid domain")
+	}
+
+	if locale.path != "old/path" {
+		t.Errorf("path changed after failed decode: %q", locale.path)
+	}
+	if locale.GetLanguage() != "old" {
+		t.Errorf("language changed after failed decode: %q", locale.GetLanguage())
+	}
+	if locale.GetDomain() != "old" {
+		t.Errorf("default domain changed after failed decode: %q", locale.GetDomain())
+	}
+	if locale.fs == nil {
+		t.Error("filesystem was cleared after failed decode")
+	}
+	if got, ok := locale.Domains["old"]; !ok || got != oldTranslator {
+		t.Error("existing domains changed after failed decode")
+	}
+	if _, ok := locale.Domains["new"]; ok {
+		t.Error("partially decoded domain was installed after failed decode")
+	}
+}
+
+func TestLocaleBinaryEncodingRace(t *testing.T) {
+	const iterations = 100
+
+	source := NewLocale("", "en")
+	source.AddTranslator("default", NewPo())
+	target := NewLocale("", "en")
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	// Each replacement uses a fresh translator so concurrent operations do not
+	// share mutable translator state.
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			domain := "domain-a"
+			if i%2 == 0 {
+				domain = "domain-b"
+			}
+			source.AddTranslator(domain, NewPo())
+			source.SetDomain(domain)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			data, err := source.MarshalBinary()
+			if err != nil {
+				t.Errorf("MarshalBinary() failed: %v", err)
+				continue
+			}
+			if err := target.UnmarshalBinary(data); err != nil {
+				t.Errorf("UnmarshalBinary() failed: %v", err)
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			_ = source.GetDomain()
+			_ = source.GetD("domain-a", "message")
+			_ = target.GetDomain()
+			_ = target.GetD("domain-b", "message")
+		}
+	}()
+
+	wg.Wait()
 }

--- a/mo.go
+++ b/mo.go
@@ -163,22 +163,18 @@ func (mo *Mo) Parse(buf []byte) {
 	defer mo.domain.trMutex.Unlock()
 	defer mo.domain.pluralMutex.Unlock()
 
-	r := bytes.NewReader(buf)
-
-	var magicNumber uint32
-	if err := binary.Read(r, binary.LittleEndian, &magicNumber); err != nil {
+	if len(buf) < 28 {
 		return
-		// return fmt.Errorf("gettext: %v", err)
 	}
+
 	var bo binary.ByteOrder
-	switch magicNumber {
+	switch binary.LittleEndian.Uint32(buf[:4]) {
 	case MoMagicLittleEndian:
 		bo = binary.LittleEndian
 	case MoMagicBigEndian:
 		bo = binary.BigEndian
 	default:
 		return
-		// return fmt.Errorf("gettext: %v", "invalid magic number")
 	}
 
 	var header struct {
@@ -190,20 +186,23 @@ func (mo *Mo) Parse(buf []byte) {
 		HashSize     uint32
 		HashOffset   uint32
 	}
-	if err := binary.Read(r, bo, &header); err != nil {
-		return
-		// return fmt.Errorf("gettext: %v", err)
-	}
-	if v := header.MajorVersion; v != 0 && v != 1 {
-		return
-		// return fmt.Errorf("gettext: %v", "invalid version number")
-	}
-	if v := header.MinorVersion; v != 0 && v != 1 {
-		return
-		// return fmt.Errorf("gettext: %v", "invalid version number")
-	}
 
 	bufLen := uint64(len(buf))
+	header.MajorVersion = bo.Uint16(buf[4:6])
+	header.MinorVersion = bo.Uint16(buf[6:8])
+	header.MsgIDCount = bo.Uint32(buf[8:12])
+	header.MsgIDOffset = bo.Uint32(buf[12:16])
+	header.MsgStrOffset = bo.Uint32(buf[16:20])
+	header.HashSize = bo.Uint32(buf[20:24])
+	header.HashOffset = bo.Uint32(buf[24:28])
+
+	if header.MajorVersion != 0 && header.MajorVersion != 1 {
+		return
+	}
+	if header.MinorVersion != 0 && header.MinorVersion != 1 {
+		return
+	}
+
 	directorySize := uint64(header.MsgIDCount) * 8
 	if uint64(header.MsgIDOffset)+directorySize > bufLen ||
 		uint64(header.MsgStrOffset)+directorySize > bufLen {
@@ -214,14 +213,16 @@ func (mo *Mo) Parse(buf []byte) {
 		msgIDEntry := int(uint64(header.MsgIDOffset) + uint64(i)*8)
 		msgIDLen := bo.Uint32(buf[msgIDEntry:])
 		msgIDStart := bo.Uint32(buf[msgIDEntry+4:])
-		if uint64(msgIDStart)+uint64(msgIDLen) > bufLen {
+		if uint64(msgIDStart) > bufLen ||
+			uint64(msgIDLen) > bufLen-uint64(msgIDStart) {
 			return
 		}
 
 		msgStrEntry := int(uint64(header.MsgStrOffset) + uint64(i)*8)
 		msgStrLen := bo.Uint32(buf[msgStrEntry:])
 		msgStrStart := bo.Uint32(buf[msgStrEntry+4:])
-		if uint64(msgStrStart)+uint64(msgStrLen) > bufLen {
+		if uint64(msgStrStart) > bufLen ||
+			uint64(msgStrLen) > bufLen-uint64(msgStrStart) {
 			return
 		}
 	}
@@ -255,11 +256,9 @@ func (mo *Mo) addTranslation(msgid, msgstr []byte) {
 	var msgctxt []byte
 	var msgidPlural []byte
 
-	d := bytes.Split(msgid, []byte(EotSeparator))
-	if len(d) == 1 {
-		msgid = d[0]
-	} else {
-		msgid, msgctxt = d[1], d[0]
+	if eotIndex := bytes.IndexByte(msgid, EotSeparator[0]); eotIndex >= 0 {
+		msgctxt = msgid[:eotIndex]
+		msgid = msgid[eotIndex+len(EotSeparator):]
 	}
 
 	if nulIndex := bytes.IndexByte(msgid, NulSeparator[0]); nulIndex >= 0 {

--- a/mo.go
+++ b/mo.go
@@ -203,66 +203,41 @@ func (mo *Mo) Parse(buf []byte) {
 		// return fmt.Errorf("gettext: %v", "invalid version number")
 	}
 
-	msgIDStart := make([]uint32, header.MsgIDCount)
-	msgIDLen := make([]uint32, header.MsgIDCount)
-	if _, err := r.Seek(int64(header.MsgIDOffset), 0); err != nil {
+	bufLen := uint64(len(buf))
+	directorySize := uint64(header.MsgIDCount) * 8
+	if uint64(header.MsgIDOffset)+directorySize > bufLen ||
+		uint64(header.MsgStrOffset)+directorySize > bufLen {
 		return
-		// return fmt.Errorf("gettext: %v", err)
-	}
-	for i := 0; i < int(header.MsgIDCount); i++ {
-		if err := binary.Read(r, bo, &msgIDLen[i]); err != nil {
-			return
-			// return fmt.Errorf("gettext: %v", err)
-		}
-		if err := binary.Read(r, bo, &msgIDStart[i]); err != nil {
-			return
-			// return fmt.Errorf("gettext: %v", err)
-		}
 	}
 
-	msgStrStart := make([]int32, header.MsgIDCount)
-	msgStrLen := make([]int32, header.MsgIDCount)
-	if _, err := r.Seek(int64(header.MsgStrOffset), 0); err != nil {
-		return
-		// return fmt.Errorf("gettext: %v", err)
-	}
-	for i := 0; i < int(header.MsgIDCount); i++ {
-		if err := binary.Read(r, bo, &msgStrLen[i]); err != nil {
+	for i := uint32(0); i < header.MsgIDCount; i++ {
+		msgIDEntry := int(uint64(header.MsgIDOffset) + uint64(i)*8)
+		msgIDLen := bo.Uint32(buf[msgIDEntry:])
+		msgIDStart := bo.Uint32(buf[msgIDEntry+4:])
+		if uint64(msgIDStart)+uint64(msgIDLen) > bufLen {
 			return
-			// return fmt.Errorf("gettext: %v", err)
 		}
-		if err := binary.Read(r, bo, &msgStrStart[i]); err != nil {
+
+		msgStrEntry := int(uint64(header.MsgStrOffset) + uint64(i)*8)
+		msgStrLen := bo.Uint32(buf[msgStrEntry:])
+		msgStrStart := bo.Uint32(buf[msgStrEntry+4:])
+		if uint64(msgStrStart)+uint64(msgStrLen) > bufLen {
 			return
-			// return fmt.Errorf("gettext: %v", err)
 		}
 	}
 
-	for i := 0; i < int(header.MsgIDCount); i++ {
-		if _, err := r.Seek(int64(msgIDStart[i]), 0); err != nil {
-			return
-			// return fmt.Errorf("gettext: %v", err)
-		}
-		msgIDData := make([]byte, msgIDLen[i])
-		if _, err := r.Read(msgIDData); err != nil {
-			return
-			// return fmt.Errorf("gettext: %v", err)
-		}
+	for i := uint32(0); i < header.MsgIDCount; i++ {
+		msgIDEntry := int(uint64(header.MsgIDOffset) + uint64(i)*8)
+		msgIDLen := bo.Uint32(buf[msgIDEntry:])
+		msgIDStart := bo.Uint32(buf[msgIDEntry+4:])
+		msgIDEnd := int(uint64(msgIDStart) + uint64(msgIDLen))
 
-		if _, err := r.Seek(int64(msgStrStart[i]), 0); err != nil {
-			return
-			// return fmt.Errorf("gettext: %v", err)
-		}
-		msgStrData := make([]byte, msgStrLen[i])
-		if _, err := r.Read(msgStrData); err != nil {
-			return
-			// return fmt.Errorf("gettext: %v", err)
-		}
+		msgStrEntry := int(uint64(header.MsgStrOffset) + uint64(i)*8)
+		msgStrLen := bo.Uint32(buf[msgStrEntry:])
+		msgStrStart := bo.Uint32(buf[msgStrEntry+4:])
+		msgStrEnd := int(uint64(msgStrStart) + uint64(msgStrLen))
 
-		if len(msgIDData) == 0 {
-			mo.addTranslation(msgIDData, msgStrData)
-		} else {
-			mo.addTranslation(msgIDData, msgStrData)
-		}
+		mo.addTranslation(buf[int(msgIDStart):msgIDEnd], buf[int(msgStrStart):msgStrEnd])
 	}
 
 	// Parse headers
@@ -287,24 +262,20 @@ func (mo *Mo) addTranslation(msgid, msgstr []byte) {
 		msgid, msgctxt = d[1], d[0]
 	}
 
-	dd := bytes.Split(msgid, []byte(NulSeparator))
-	if len(dd) > 1 {
-		msgid = dd[0]
-		dd = dd[1:]
+	if nulIndex := bytes.IndexByte(msgid, NulSeparator[0]); nulIndex >= 0 {
+		msgidPlural = msgid[nulIndex+1:]
+		msgid = msgid[:nulIndex]
 	}
-
 	translation.ID = string(msgid)
 
-	msgidPlural = bytes.Join(dd, []byte(NulSeparator))
 	if len(msgidPlural) > 0 {
 		translation.PluralID = string(msgidPlural)
 	}
 
-	ddd := bytes.Split(msgstr, []byte(NulSeparator))
-	if len(ddd) > 0 {
-		for i, s := range ddd {
-			translation.Trs[i] = string(s)
-		}
+	i := 0
+	for s := range bytes.SplitSeq(msgstr, []byte(NulSeparator)) {
+		translation.Trs[i] = string(s)
+		i++
 	}
 
 	if len(msgctxt) > 0 {

--- a/mo_test.go
+++ b/mo_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -726,6 +727,48 @@ func FuzzMoRejectedCatalogDoesNotMutate(f *testing.F) {
 		}
 		if got := mo.GetDomain().GetCtxTranslations(); !reflect.DeepEqual(got, wantContextTranslations) {
 			t.Fatalf("context translations changed: got %#v, want %#v", got, wantContextTranslations)
+		}
+	})
+}
+
+func FuzzMoSharedTranslationPayload(f *testing.F) {
+	f.Add("shared translation", uint8(0))
+	f.Add("geteilte Übersetzung", uint8(1))
+
+	f.Fuzz(func(t *testing.T, suffix string, mode uint8) {
+		if len(suffix) > 64<<10 || strings.IndexByte(suffix, 0) >= 0 {
+			return
+		}
+
+		var order binary.ByteOrder = binary.LittleEndian
+		if mode&1 != 0 {
+			order = binary.BigEndian
+		}
+		shared := []byte("shared:" + suffix)
+		buf := makeMoFixture(
+			order,
+			moFixtureEntry{msgid: []byte("first"), msgstr: shared},
+			moFixtureEntry{msgid: []byte("second"), msgstr: []byte("unused")},
+		)
+
+		const (
+			firstTranslationDescriptor  = 44
+			secondTranslationDescriptor = 52
+		)
+		copy(
+			buf[secondTranslationDescriptor:secondTranslationDescriptor+8],
+			buf[firstTranslationDescriptor:firstTranslationDescriptor+8],
+		)
+
+		mo := NewMo()
+		mo.Parse(buf)
+
+		want := string(shared)
+		if got := mo.Get("first"); got != want {
+			t.Fatalf("first translation = %q, want %q", got, want)
+		}
+		if got := mo.Get("second"); got != want {
+			t.Fatalf("shared translation = %q, want %q", got, want)
 		}
 	})
 }

--- a/mo_test.go
+++ b/mo_test.go
@@ -6,6 +6,7 @@
 package gotext
 
 import (
+	"encoding/binary"
 	"os"
 	"path"
 	"testing"
@@ -268,5 +269,109 @@ func TestMo_MissingWrappers(t *testing.T) {
 	}
 	if mo.IsTranslatedNC("id", 1, "ctx") {
 		t.Error("Mo.IsTranslatedNC failed")
+	}
+}
+
+func TestMoParseRejectsHugeCount(t *testing.T) {
+	buf := make([]byte, 28)
+	binary.LittleEndian.PutUint32(buf[0:4], MoMagicLittleEndian)
+	binary.LittleEndian.PutUint32(buf[8:12], ^uint32(0))
+
+	mo := NewMo()
+	mo.GetDomain().Set("seed", "preserved")
+	mo.Parse(buf)
+
+	if got := mo.Get("seed"); got != "preserved" {
+		t.Fatalf("seed translation = %q, want %q", got, "preserved")
+	}
+	if len(mo.domain.translations) != 1 {
+		t.Fatalf("translations = %v, want only the seed", mo.domain.translations)
+	}
+}
+
+func TestMoParseRejectsInvalidPayloadWithoutMutation(t *testing.T) {
+	t.Run("payload extends past file", func(t *testing.T) {
+		buf := make([]byte, 46)
+		binary.LittleEndian.PutUint32(buf[0:4], MoMagicLittleEndian)
+		binary.LittleEndian.PutUint32(buf[8:12], 1)
+		binary.LittleEndian.PutUint32(buf[12:16], 28)
+		binary.LittleEndian.PutUint32(buf[16:20], 36)
+		binary.LittleEndian.PutUint32(buf[28:32], 4)
+		binary.LittleEndian.PutUint32(buf[32:36], 44)
+		binary.LittleEndian.PutUint32(buf[36:40], 1)
+		binary.LittleEndian.PutUint32(buf[40:44], 45)
+		copy(buf[44:], "xy")
+
+		mo := NewMo()
+		mo.GetDomain().Set("seed", "preserved")
+		mo.Parse(buf)
+
+		if got := mo.Get("seed"); got != "preserved" {
+			t.Fatalf("seed translation = %q, want %q", got, "preserved")
+		}
+		if len(mo.domain.translations) != 1 {
+			t.Fatalf("translations = %v, want only the seed", mo.domain.translations)
+		}
+	})
+
+	t.Run("later payload invalidates all entries", func(t *testing.T) {
+		buf := make([]byte, 70)
+		binary.LittleEndian.PutUint32(buf[0:4], MoMagicLittleEndian)
+		binary.LittleEndian.PutUint32(buf[8:12], 2)
+		binary.LittleEndian.PutUint32(buf[12:16], 28)
+		binary.LittleEndian.PutUint32(buf[16:20], 44)
+
+		binary.LittleEndian.PutUint32(buf[28:32], 3)
+		binary.LittleEndian.PutUint32(buf[32:36], 60)
+		binary.LittleEndian.PutUint32(buf[36:40], 3)
+		binary.LittleEndian.PutUint32(buf[40:44], 66)
+
+		binary.LittleEndian.PutUint32(buf[44:48], 3)
+		binary.LittleEndian.PutUint32(buf[48:52], 63)
+		binary.LittleEndian.PutUint32(buf[52:56], 3)
+		binary.LittleEndian.PutUint32(buf[56:60], 69)
+		copy(buf[60:], "oneONEtwoT")
+
+		mo := NewMo()
+		mo.GetDomain().Set("seed", "preserved")
+		mo.Parse(buf)
+
+		if got := mo.Get("seed"); got != "preserved" {
+			t.Fatalf("seed translation = %q, want %q", got, "preserved")
+		}
+		if len(mo.domain.translations) != 1 {
+			t.Fatalf("translations = %v, want only the seed", mo.domain.translations)
+		}
+	})
+}
+
+func TestMoAddTranslationPreservesPluralBytes(t *testing.T) {
+	mo := NewMo()
+	mo.addTranslation(
+		[]byte("id\x00plural\x00extra"),
+		[]byte("one\x00two\x00three"),
+	)
+
+	translation, ok := mo.domain.translations["id"]
+	if !ok {
+		t.Fatal("expected translation for repeated-NUL msgid")
+	}
+	if got := translation.PluralID; got != "plural\x00extra" {
+		t.Fatalf("plural ID = %q, want %q", got, "plural\x00extra")
+	}
+	for i, want := range map[int]string{0: "one", 1: "two", 2: "three"} {
+		if got := translation.Trs[i]; got != want {
+			t.Fatalf("translation form %d = %q, want %q", i, got, want)
+		}
+	}
+	if len(translation.Trs) != 3 {
+		t.Fatalf("translation forms = %v, want 3 forms", translation.Trs)
+	}
+
+	mo = NewMo()
+	mo.addTranslation([]byte("singular"), []byte("translated"))
+	translation = mo.domain.translations["singular"]
+	if got := translation.PluralID; got != "" {
+		t.Fatalf("singular plural ID = %q, want empty", got)
 	}
 }

--- a/mo_test.go
+++ b/mo_test.go
@@ -275,7 +275,7 @@ func TestMo_MissingWrappers(t *testing.T) {
 
 func TestMoParseRejectsHugeCount(t *testing.T) {
 	buf := make([]byte, 28)
-	binary.LittleEndian.PutUint32(buf[0:4], MoMagicLittleEndian)
+	copy(buf[0:4], []byte{0xde, 0x12, 0x04, 0x95})
 	binary.LittleEndian.PutUint32(buf[8:12], ^uint32(0))
 
 	mo := NewMo()
@@ -293,7 +293,7 @@ func TestMoParseRejectsHugeCount(t *testing.T) {
 func TestMoParseRejectsInvalidPayloadWithoutMutation(t *testing.T) {
 	t.Run("payload extends past file", func(t *testing.T) {
 		buf := make([]byte, 46)
-		binary.LittleEndian.PutUint32(buf[0:4], MoMagicLittleEndian)
+		copy(buf[0:4], []byte{0xde, 0x12, 0x04, 0x95})
 		binary.LittleEndian.PutUint32(buf[8:12], 1)
 		binary.LittleEndian.PutUint32(buf[12:16], 28)
 		binary.LittleEndian.PutUint32(buf[16:20], 36)
@@ -317,7 +317,7 @@ func TestMoParseRejectsInvalidPayloadWithoutMutation(t *testing.T) {
 
 	t.Run("later payload invalidates all entries", func(t *testing.T) {
 		buf := make([]byte, 70)
-		binary.LittleEndian.PutUint32(buf[0:4], MoMagicLittleEndian)
+		copy(buf[0:4], []byte{0xde, 0x12, 0x04, 0x95})
 		binary.LittleEndian.PutUint32(buf[8:12], 2)
 		binary.LittleEndian.PutUint32(buf[12:16], 28)
 		binary.LittleEndian.PutUint32(buf[16:20], 44)
@@ -346,12 +346,19 @@ func TestMoParseRejectsInvalidPayloadWithoutMutation(t *testing.T) {
 	})
 }
 
-func TestMoAddTranslationPreservesPluralBytes(t *testing.T) {
+func TestMoParsePreservesPluralBytes(t *testing.T) {
 	mo := NewMo()
-	mo.addTranslation(
-		[]byte("id\x00plural\x00extra"),
-		[]byte("one\x00two\x00three"),
-	)
+	mo.Parse(makeMoFixture(
+		binary.LittleEndian,
+		moFixtureEntry{
+			msgid:  []byte("id\x00plural\x00extra"),
+			msgstr: []byte("one\x00two\x00three"),
+		},
+		moFixtureEntry{
+			msgid:  []byte("singular"),
+			msgstr: []byte("translated"),
+		},
+	))
 
 	translation, ok := mo.domain.translations["id"]
 	if !ok {
@@ -369,11 +376,15 @@ func TestMoAddTranslationPreservesPluralBytes(t *testing.T) {
 		t.Fatalf("translation forms = %v, want 3 forms", translation.Trs)
 	}
 
-	mo = NewMo()
-	mo.addTranslation([]byte("singular"), []byte("translated"))
-	translation = mo.domain.translations["singular"]
+	translation, ok = mo.domain.translations["singular"]
+	if !ok {
+		t.Fatal("expected singular translation")
+	}
 	if got := translation.PluralID; got != "" {
 		t.Fatalf("singular plural ID = %q, want empty", got)
+	}
+	if got := translation.Trs[0]; got != "translated" {
+		t.Fatalf("singular translation = %q, want %q", got, "translated")
 	}
 }
 
@@ -383,7 +394,10 @@ type moFixtureEntry struct {
 }
 
 func makeMoFixture(order binary.ByteOrder, entries ...moFixtureEntry) []byte {
-	const headerSize = 28
+	const (
+		headerSize = 28
+		moMagic    = uint32(0x950412de)
+	)
 	directorySize := len(entries) * 8
 	msgIDOffset := headerSize
 	msgStrOffset := msgIDOffset + directorySize
@@ -391,11 +405,12 @@ func makeMoFixture(order binary.ByteOrder, entries ...moFixtureEntry) []byte {
 
 	dataSize := 0
 	for _, entry := range entries {
-		dataSize += len(entry.msgid) + len(entry.msgstr)
+		// MO string lengths exclude their trailing NUL bytes.
+		dataSize += len(entry.msgid) + 1 + len(entry.msgstr) + 1
 	}
 	buf := make([]byte, dataOffset+dataSize)
 
-	order.PutUint32(buf[0:4], MoMagicLittleEndian)
+	order.PutUint32(buf[0:4], moMagic)
 	order.PutUint32(buf[8:12], uint32(len(entries)))
 	order.PutUint32(buf[12:16], uint32(msgIDOffset))
 	order.PutUint32(buf[16:20], uint32(msgStrOffset))
@@ -407,12 +422,12 @@ func makeMoFixture(order binary.ByteOrder, entries ...moFixtureEntry) []byte {
 		order.PutUint32(buf[idEntry:idEntry+4], uint32(len(entry.msgid)))
 		order.PutUint32(buf[idEntry+4:idEntry+8], uint32(cursor))
 		copy(buf[cursor:], entry.msgid)
-		cursor += len(entry.msgid)
+		cursor += len(entry.msgid) + 1
 
 		order.PutUint32(buf[strEntry:strEntry+4], uint32(len(entry.msgstr)))
 		order.PutUint32(buf[strEntry+4:strEntry+8], uint32(cursor))
 		copy(buf[cursor:], entry.msgstr)
-		cursor += len(entry.msgstr)
+		cursor += len(entry.msgstr) + 1
 	}
 
 	return buf
@@ -486,22 +501,28 @@ func TestMoParseRejectsInvalidMagicWithoutMutation(t *testing.T) {
 	}
 }
 
-func TestMoAddTranslationPreservesEotSuffix(t *testing.T) {
+func TestMoParsePreservesEotSuffix(t *testing.T) {
 	mo := NewMo()
-	mo.addTranslation(
-		[]byte("menu\x04item\x04suffix\x00items"),
-		[]byte("one\x00many"),
-	)
+	mo.Parse(makeMoFixture(
+		binary.LittleEndian,
+		moFixtureEntry{
+			msgid:  []byte("menu\x04item\x04suffix\x00items"),
+			msgstr: []byte("one\x00many"),
+		},
+	))
 
 	translation, ok := mo.GetDomain().contextTranslations["menu"]["item\x04suffix"]
 	if !ok {
 		t.Fatal("expected context translation with EOT suffix")
 	}
 	if got := translation.ID; got != "item\x04suffix" {
-		t.Fatalf("translation ID = %q, want %q", got, "item\\x04suffix")
+		t.Fatalf("translation ID = %q, want %q", got, "item\x04suffix")
 	}
 	if got := translation.PluralID; got != "items" {
 		t.Fatalf("plural ID = %q, want %q", got, "items")
+	}
+	if got := mo.GetNC("item\x04suffix", "items", 2, "menu"); got != "many" {
+		t.Fatalf("plural context lookup = %q, want %q", got, "many")
 	}
 }
 
@@ -529,7 +550,7 @@ func TestMoParseTruncatedHeaderPreservesSeed(t *testing.T) {
 
 func TestMoParseRejectsDirectoryOneByteOverflow(t *testing.T) {
 	buf := make([]byte, 35)
-	binary.LittleEndian.PutUint32(buf[0:4], MoMagicLittleEndian)
+	copy(buf[0:4], []byte{0xde, 0x12, 0x04, 0x95})
 	binary.LittleEndian.PutUint32(buf[8:12], 1)
 	binary.LittleEndian.PutUint32(buf[12:16], 28)
 	binary.LittleEndian.PutUint32(buf[16:20], 28)

--- a/mo_test.go
+++ b/mo_test.go
@@ -7,6 +7,7 @@ package gotext
 
 import (
 	"encoding/binary"
+	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -374,4 +375,273 @@ func TestMoAddTranslationPreservesPluralBytes(t *testing.T) {
 	if got := translation.PluralID; got != "" {
 		t.Fatalf("singular plural ID = %q, want empty", got)
 	}
+}
+
+type moFixtureEntry struct {
+	msgid  []byte
+	msgstr []byte
+}
+
+func makeMoFixture(order binary.ByteOrder, entries ...moFixtureEntry) []byte {
+	const headerSize = 28
+	directorySize := len(entries) * 8
+	msgIDOffset := headerSize
+	msgStrOffset := msgIDOffset + directorySize
+	dataOffset := msgStrOffset + directorySize
+
+	dataSize := 0
+	for _, entry := range entries {
+		dataSize += len(entry.msgid) + len(entry.msgstr)
+	}
+	buf := make([]byte, dataOffset+dataSize)
+
+	order.PutUint32(buf[0:4], MoMagicLittleEndian)
+	order.PutUint32(buf[8:12], uint32(len(entries)))
+	order.PutUint32(buf[12:16], uint32(msgIDOffset))
+	order.PutUint32(buf[16:20], uint32(msgStrOffset))
+
+	cursor := dataOffset
+	for i, entry := range entries {
+		idEntry := msgIDOffset + i*8
+		strEntry := msgStrOffset + i*8
+		order.PutUint32(buf[idEntry:idEntry+4], uint32(len(entry.msgid)))
+		order.PutUint32(buf[idEntry+4:idEntry+8], uint32(cursor))
+		copy(buf[cursor:], entry.msgid)
+		cursor += len(entry.msgid)
+
+		order.PutUint32(buf[strEntry:strEntry+4], uint32(len(entry.msgstr)))
+		order.PutUint32(buf[strEntry+4:strEntry+8], uint32(cursor))
+		copy(buf[cursor:], entry.msgstr)
+		cursor += len(entry.msgstr)
+	}
+
+	return buf
+}
+
+func TestMoParseBigEndianSingularContextPlural(t *testing.T) {
+	catalog := makeMoFixture(
+		binary.BigEndian,
+		moFixtureEntry{
+			msgid:  []byte(""),
+			msgstr: []byte("Language: xx\nPlural-Forms: nplurals=2; plural=(n != 1);\n"),
+		},
+		moFixtureEntry{
+			msgid:  []byte("hello"),
+			msgstr: []byte("bonjour"),
+		},
+		moFixtureEntry{
+			msgid:  []byte("menu\x04title"),
+			msgstr: []byte("Title"),
+		},
+		moFixtureEntry{
+			msgid:  []byte("menu\x04item\x00items"),
+			msgstr: []byte("one\x00many"),
+		},
+	)
+
+	mo := NewMo()
+	mo.Parse(catalog)
+
+	if got := mo.Get("hello"); got != "bonjour" {
+		t.Fatalf("singular lookup = %q, want %q", got, "bonjour")
+	}
+	if got := mo.GetC("title", "menu"); got != "Title" {
+		t.Fatalf("context lookup = %q, want %q", got, "Title")
+	}
+
+	translation, ok := mo.GetDomain().contextTranslations["menu"]["item"]
+	if !ok {
+		t.Fatal("expected big-endian context translation")
+	}
+	if got := translation.PluralID; got != "items" {
+		t.Fatalf("plural ID = %q, want %q", got, "items")
+	}
+	if got := translation.Trs[0]; got != "one" {
+		t.Fatalf("translation form 0 = %q, want %q", got, "one")
+	}
+	if got := translation.Trs[1]; got != "many" {
+		t.Fatalf("translation form 1 = %q, want %q", got, "many")
+	}
+	if got := mo.GetNC("item", "items", 2, "menu"); got != "many" {
+		t.Fatalf("plural context lookup = %q, want %q", got, "many")
+	}
+}
+
+func TestMoParseRejectsInvalidMagicWithoutMutation(t *testing.T) {
+	catalog := makeMoFixture(
+		binary.BigEndian,
+		moFixtureEntry{msgid: []byte("id"), msgstr: []byte("translated")},
+	)
+	copy(catalog[:4], []byte{0x95, 0x04, 0x12, 0xdf})
+
+	mo := NewMo()
+	mo.GetDomain().Set("sentinel", "preserved")
+	mo.Parse(catalog)
+
+	if got := mo.Get("sentinel"); got != "preserved" {
+		t.Fatalf("sentinel translation = %q, want %q", got, "preserved")
+	}
+	if len(mo.GetDomain().translations) != 1 {
+		t.Fatalf("translations = %v, want only the sentinel", mo.GetDomain().translations)
+	}
+}
+
+func TestMoAddTranslationPreservesEotSuffix(t *testing.T) {
+	mo := NewMo()
+	mo.addTranslation(
+		[]byte("menu\x04item\x04suffix\x00items"),
+		[]byte("one\x00many"),
+	)
+
+	translation, ok := mo.GetDomain().contextTranslations["menu"]["item\x04suffix"]
+	if !ok {
+		t.Fatal("expected context translation with EOT suffix")
+	}
+	if got := translation.ID; got != "item\x04suffix" {
+		t.Fatalf("translation ID = %q, want %q", got, "item\\x04suffix")
+	}
+	if got := translation.PluralID; got != "items" {
+		t.Fatalf("plural ID = %q, want %q", got, "items")
+	}
+}
+
+func TestMoParseTruncatedHeaderPreservesSeed(t *testing.T) {
+	catalog := makeMoFixture(
+		binary.LittleEndian,
+		moFixtureEntry{msgid: []byte("id"), msgstr: []byte("translated")},
+	)
+
+	for size := 0; size <= 27; size++ {
+		t.Run(fmt.Sprintf("truncate_%d", size), func(t *testing.T) {
+			mo := NewMo()
+			mo.GetDomain().Set("sentinel", "preserved")
+			mo.Parse(catalog[:size])
+
+			if got := mo.Get("sentinel"); got != "preserved" {
+				t.Fatalf("sentinel translation = %q, want %q", got, "preserved")
+			}
+			if len(mo.GetDomain().translations) != 1 {
+				t.Fatalf("translations = %v, want only the sentinel", mo.GetDomain().translations)
+			}
+		})
+	}
+}
+
+func TestMoParseRejectsDirectoryOneByteOverflow(t *testing.T) {
+	buf := make([]byte, 35)
+	binary.LittleEndian.PutUint32(buf[0:4], MoMagicLittleEndian)
+	binary.LittleEndian.PutUint32(buf[8:12], 1)
+	binary.LittleEndian.PutUint32(buf[12:16], 28)
+	binary.LittleEndian.PutUint32(buf[16:20], 28)
+
+	mo := NewMo()
+	mo.GetDomain().Set("sentinel", "preserved")
+	mo.Parse(buf)
+
+	if got := mo.Get("sentinel"); got != "preserved" {
+		t.Fatalf("sentinel translation = %q, want %q", got, "preserved")
+	}
+	if len(mo.GetDomain().translations) != 1 {
+		t.Fatalf("translations = %v, want only the sentinel", mo.GetDomain().translations)
+	}
+}
+
+func TestMoParseRejectsNearMaxUint32Offsets(t *testing.T) {
+	base := makeMoFixture(
+		binary.LittleEndian,
+		moFixtureEntry{msgid: []byte("id"), msgstr: []byte("translated")},
+	)
+	maxUint32 := ^uint32(0)
+	tests := []struct {
+		name   string
+		mutate func([]byte)
+	}{
+		{
+			name: "msgid directory offset",
+			mutate: func(buf []byte) {
+				binary.LittleEndian.PutUint32(buf[12:16], maxUint32)
+			},
+		},
+		{
+			name: "msgstr directory offset",
+			mutate: func(buf []byte) {
+				binary.LittleEndian.PutUint32(buf[16:20], maxUint32)
+			},
+		},
+		{
+			name: "msgid payload offset",
+			mutate: func(buf []byte) {
+				binary.LittleEndian.PutUint32(buf[32:36], maxUint32)
+			},
+		},
+		{
+			name: "msgstr payload offset",
+			mutate: func(buf []byte) {
+				binary.LittleEndian.PutUint32(buf[40:44], maxUint32)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			catalog := append([]byte(nil), base...)
+			test.mutate(catalog)
+
+			mo := NewMo()
+			mo.GetDomain().Set("sentinel", "preserved")
+			mo.Parse(catalog)
+
+			if got := mo.Get("sentinel"); got != "preserved" {
+				t.Fatalf("sentinel translation = %q, want %q", got, "preserved")
+			}
+			if len(mo.GetDomain().translations) != 1 {
+				t.Fatalf("translations = %v, want only the sentinel", mo.GetDomain().translations)
+			}
+		})
+	}
+}
+
+func FuzzMoParseBoundedCatalog(f *testing.F) {
+	littleEndianCatalog := makeMoFixture(
+		binary.LittleEndian,
+		moFixtureEntry{msgid: []byte("id"), msgstr: []byte("translated")},
+	)
+	bigEndianCatalog := makeMoFixture(
+		binary.BigEndian,
+		moFixtureEntry{msgid: []byte("id"), msgstr: []byte("translated")},
+	)
+
+	f.Add(littleEndianCatalog)
+	f.Add(bigEndianCatalog)
+	f.Add([]byte{})
+	f.Add([]byte("not an MO catalog"))
+	f.Add(littleEndianCatalog[:27])
+	f.Add([]byte{0xde, 0x12, 0x04, 0x95, 0, 0, 0, 0})
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		if len(input) > 64<<10 {
+			return
+		}
+
+		mo := NewMo()
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				t.Fatalf("Parse panicked: %v", recovered)
+			}
+		}()
+
+		mo.Parse(input)
+		for id, translation := range mo.GetDomain().translations {
+			if translation == nil {
+				t.Fatalf("translation %q is nil", id)
+			}
+		}
+		for context, translations := range mo.GetDomain().contextTranslations {
+			for id, translation := range translations {
+				if translation == nil {
+					t.Fatalf("context translation %q/%q is nil", context, id)
+				}
+			}
+		}
+	})
 }

--- a/mo_test.go
+++ b/mo_test.go
@@ -669,10 +669,11 @@ func FuzzMoParseBoundedCatalog(f *testing.F) {
 }
 
 func FuzzMoRejectedCatalogDoesNotMutate(f *testing.F) {
-	f.Add([]byte("rejected catalog"))
-	f.Add([]byte{})
+	f.Add([]byte("rejected catalog"), uint8(0))
+	f.Add([]byte{}, uint8(1))
+	f.Add([]byte("big endian"), uint8(3))
 
-	f.Fuzz(func(t *testing.T, input []byte) {
+	f.Fuzz(func(t *testing.T, input []byte, mode uint8) {
 		if len(input) > 64<<10 {
 			return
 		}
@@ -684,13 +685,33 @@ func FuzzMoRejectedCatalogDoesNotMutate(f *testing.F) {
 		wantTranslations := mo.GetDomain().GetTranslations()
 		wantContextTranslations := mo.GetDomain().GetCtxTranslations()
 
-		buf := make([]byte, 28+len(input))
-		copy(buf[28:], input)
-		binary.LittleEndian.PutUint32(buf[0:4], MoMagicLittleEndian)
-		binary.LittleEndian.PutUint32(buf[8:12], 1)
-		directoryOffset := uint32(len(buf) + 1)
-		binary.LittleEndian.PutUint32(buf[12:16], directoryOffset)
-		binary.LittleEndian.PutUint32(buf[16:20], directoryOffset)
+		var order binary.ByteOrder = binary.LittleEndian
+		if mode&1 != 0 {
+			order = binary.BigEndian
+		}
+		msgID := append([]byte("id:"), input...)
+		buf := makeMoFixture(
+			order,
+			moFixtureEntry{msgid: msgID, msgstr: []byte("translated")},
+		)
+
+		switch mode % 5 {
+		case 0:
+			// Keep both directories valid, but truncate the translation payload.
+			buf = buf[:len(buf)-2]
+		case 1:
+			// Overflow the original string length after both directories decode.
+			order.PutUint32(buf[28:32], ^uint32(0))
+		case 2:
+			// Point the translation payload just beyond the complete catalog.
+			order.PutUint32(buf[40:44], uint32(len(buf)+1))
+		case 3:
+			// Overflow the translation string length after both directories decode.
+			order.PutUint32(buf[36:40], ^uint32(0))
+		case 4:
+			// Corrupt the selected endian encoding's canonical magic.
+			buf[0] ^= 0xff
+		}
 
 		defer func() {
 			if recovered := recover(); recovered != nil {

--- a/mo_test.go
+++ b/mo_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"reflect"
 	"testing"
 )
 
@@ -663,6 +664,47 @@ func FuzzMoParseBoundedCatalog(f *testing.F) {
 					t.Fatalf("context translation %q/%q is nil", context, id)
 				}
 			}
+		}
+	})
+}
+
+func FuzzMoRejectedCatalogDoesNotMutate(f *testing.F) {
+	f.Add([]byte("rejected catalog"))
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		if len(input) > 64<<10 {
+			return
+		}
+
+		mo := NewMo()
+		mo.GetDomain().Set("ordinary id", "ordinary translation")
+		mo.GetDomain().SetC("contextual id", "context", "contextual translation")
+
+		wantTranslations := mo.GetDomain().GetTranslations()
+		wantContextTranslations := mo.GetDomain().GetCtxTranslations()
+
+		buf := make([]byte, 28+len(input))
+		copy(buf[28:], input)
+		binary.LittleEndian.PutUint32(buf[0:4], MoMagicLittleEndian)
+		binary.LittleEndian.PutUint32(buf[8:12], 1)
+		directoryOffset := uint32(len(buf) + 1)
+		binary.LittleEndian.PutUint32(buf[12:16], directoryOffset)
+		binary.LittleEndian.PutUint32(buf[16:20], directoryOffset)
+
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				t.Fatalf("Parse panicked: %v", recovered)
+			}
+		}()
+
+		mo.Parse(buf)
+
+		if got := mo.GetDomain().GetTranslations(); !reflect.DeepEqual(got, wantTranslations) {
+			t.Fatalf("ordinary translations changed: got %#v, want %#v", got, wantTranslations)
+		}
+		if got := mo.GetDomain().GetCtxTranslations(); !reflect.DeepEqual(got, wantContextTranslations) {
+			t.Fatalf("context translations changed: got %#v, want %#v", got, wantContextTranslations)
 		}
 	})
 }

--- a/plurals/compiler.go
+++ b/plurals/compiler.go
@@ -12,18 +12,11 @@ package plurals
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"slices"
 	"strconv"
 	"strings"
+	"unicode"
 )
-
-type match struct {
-	openPos  int
-	closePos int
-}
-
-var pat = regexp.MustCompile(`(\?|:|\|\||&&|==|!=|>=|>|<=|<|%|\d+|n|\(|\))`)
 
 type testToken interface {
 	compile(tokens []string) (test test, err error)
@@ -32,30 +25,30 @@ type testToken interface {
 type cmpTestBuilder func(val uint32, flipped bool) test
 type logicTestBuild func(left test, right test) test
 
-var ternaryToken ternaryStruct
+func compileTernary(tokens []string, depth int) (expr Expression, err error) {
+	if depth > maxParseDepth {
+		return nil, errors.New("expression nesting is too deep")
+	}
 
-type ternaryStruct struct{}
-
-func (ternaryStruct) compile(tokens []string) (expr Expression, err error) {
 	main, err := splitTokens(tokens, "?")
 	if err != nil {
-		return expr, err
+		return nil, err
 	}
-	test, err := compileTest(strings.Join(main.Left, ""))
+	test, err := compileTestDepth(strings.Join(main.Left, ""), depth+1)
 	if err != nil {
-		return expr, err
+		return nil, err
 	}
-	actions, err := splitTokens(main.Right, ":")
+	actions, err := splitTernaryTokens(main.Right)
 	if err != nil {
-		return expr, err
+		return nil, err
 	}
-	trueAction, err := compileExpression(strings.Join(actions.Left, ""))
+	trueAction, err := compileExpressionDepth(strings.Join(actions.Left, ""), depth+1)
 	if err != nil {
-		return expr, err
+		return nil, err
 	}
-	falseAction, err := compileExpression(strings.Join(actions.Right, ""))
+	falseAction, err := compileExpressionDepth(strings.Join(actions.Right, ""), depth+1)
 	if err != nil {
-		return expr, err
+		return nil, err
 	}
 	return ternary{
 		test:      test,
@@ -64,36 +57,64 @@ func (ternaryStruct) compile(tokens []string) (expr Expression, err error) {
 	}, nil
 }
 
+const maxParseDepth = 1024
+
+func splitTernaryTokens(tokens []string) (s splitted, err error) {
+	depth := 0
+	for index, token := range tokens {
+		switch token {
+		case "?":
+			depth++
+		case ":":
+			if depth == 0 {
+				return splitted{
+					Left:  tokens[:index],
+					Right: tokens[index+1:],
+				}, nil
+			}
+			depth--
+		}
+	}
+	return s, errors.New("':' not found for ternary expression")
+}
+
 var constToken constValStruct
 
 type constValStruct struct{}
 
 func (constValStruct) compile(tokens []string) (expr Expression, err error) {
 	if len(tokens) == 0 {
-		return expr, errors.New("got nothing instead of constant")
+		return nil, errors.New("got nothing instead of constant")
 	}
 	if len(tokens) != 1 {
-		return expr, fmt.Errorf("invalid constant: %s", strings.Join(tokens, ""))
+		return nil, fmt.Errorf("invalid constant: %s", strings.Join(tokens, ""))
 	}
 	i, err := strconv.Atoi(tokens[0])
 	if err != nil {
-		return expr, err
+		return nil, err
 	}
 	return constValue{value: i}, nil
 }
 
 func compileLogicTest(tokens []string, sep string, builder logicTestBuild) (test test, err error) {
+	return compileLogicTestDepth(tokens, sep, builder, 0)
+}
+
+func compileLogicTestDepth(tokens []string, sep string, builder logicTestBuild, depth int) (test test, err error) {
+	if depth > maxParseDepth {
+		return nil, errors.New("expression nesting is too deep")
+	}
 	split, err := splitTokens(tokens, sep)
 	if err != nil {
-		return test, err
+		return nil, err
 	}
-	left, err := compileTest(strings.Join(split.Left, ""))
+	left, err := compileTestDepth(strings.Join(split.Left, ""), depth+1)
 	if err != nil {
-		return test, err
+		return nil, err
 	}
-	right, err := compileTest(strings.Join(split.Right, ""))
+	right, err := compileTestDepth(strings.Join(split.Right, ""), depth+1)
 	if err != nil {
-		return test, err
+		return nil, err
 	}
 	return builder(left, right), nil
 }
@@ -120,40 +141,79 @@ func buildAnd(left test, right test) test {
 	return and{left: left, right: right}
 }
 
+func unwrapSingleGroup(tokens []string) ([]string, error) {
+	for len(tokens) == 1 && strings.HasPrefix(tokens[0], "(") {
+		inner, err := tokenize(tokens[0])
+		if err != nil {
+			return nil, err
+		}
+		if len(inner) == 1 && inner[0] == tokens[0] {
+			break
+		}
+		tokens = inner
+	}
+	return tokens, nil
+}
+
+func isSimpleN(tokens []string) bool {
+	tokens, err := unwrapSingleGroup(tokens)
+	if err != nil || len(tokens) != 1 {
+		return false
+	}
+	return tokens[0] == "n"
+}
+
+func parseLiteralTokens(tokens []string) (uint32, error) {
+	tokens, err := unwrapSingleGroup(tokens)
+	if err != nil {
+		return 0, err
+	}
+	if len(tokens) != 1 {
+		return 0, errors.New("expected a single integer")
+	}
+	return parseUint32(tokens[0])
+}
+
+func containsSimpleN(tokens []string) bool {
+	for _, token := range tokens {
+		if isSimpleN([]string{token}) {
+			return true
+		}
+	}
+	return false
+}
+
 func compileMod(tokens []string) (math math, err error) {
 	split, err := splitTokens(tokens, "%")
 	if err != nil {
 		return math, err
 	}
-	if len(split.Left) != 1 || split.Left[0] != "n" {
+	if !isSimpleN(split.Left) {
 		return math, errors.New("modulus operation requires 'n' as left operand")
 	}
-	if len(split.Right) != 1 {
-		return math, errors.New("modulus operation requires simple integer as right operand")
-	}
-	i, err := parseUint32(split.Right[0])
+	i, err := parseLiteralTokens(split.Right)
 	if err != nil {
 		return math, err
 	}
 	if i == 0 {
 		return math, errors.New("modulus operation requires a non-zero integer as right operand")
 	}
-	return mod{value: uint32(i)}, nil
+	return mod{value: i}, nil
 }
 
 func subPipe(modTokens []string, actionTokens []string, builder cmpTestBuilder, flipped bool) (test test, err error) {
 	modifier, err := compileMod(modTokens)
 	if err != nil {
-		return test, err
+		return nil, err
 	}
-	if len(actionTokens) != 1 {
-		return test, errors.New("can only get modulus of integer")
+	if len(actionTokens) == 0 {
+		return nil, errors.New("can only get modulus of integer")
 	}
-	i, err := parseUint32(actionTokens[0])
+	i, err := parseLiteralTokens(actionTokens)
 	if err != nil {
-		return test, err
+		return nil, err
 	}
-	action := builder(uint32(i), flipped)
+	action := builder(i, flipped)
 	return pipe{
 		modifier: modifier,
 		action:   action,
@@ -163,30 +223,37 @@ func subPipe(modTokens []string, actionTokens []string, builder cmpTestBuilder, 
 func compileEquality(tokens []string, sep string, builder cmpTestBuilder) (test test, err error) {
 	split, err := splitTokens(tokens, sep)
 	if err != nil {
-		return test, err
+		return nil, err
 	}
-	if slices.Contains(split.Left, "n") && !slices.Contains(split.Left, "%") && len(split.Left) == 1 {
-		i, err := parseUint32(strings.Join(split.Right, ""))
+	left, err := unwrapSingleGroup(split.Left)
+	if err != nil {
+		return nil, err
+	}
+	right, err := unwrapSingleGroup(split.Right)
+	if err != nil {
+		return nil, err
+	}
+	if isSimpleN(left) {
+		i, err := parseLiteralTokens(right)
 		if err != nil {
-			// Try to compile it as a full expression if it's not a simple integer
-			// but for now we follow the existing pattern of expecting integers here
-			// unless it's a mod operation.
-			return test, err
+			return nil, err
 		}
 		return builder(i, false), nil
-	} else if slices.Contains(split.Right, "n") && !slices.Contains(split.Right, "%") && len(split.Right) == 1 {
-		i, err := parseUint32(strings.Join(split.Left, ""))
+	}
+	if isSimpleN(right) {
+		i, err := parseLiteralTokens(left)
 		if err != nil {
-			return test, err
+			return nil, err
 		}
 		return builder(i, true), nil
-	} else if slices.Contains(split.Left, "n") && slices.Contains(split.Left, "%") {
-		return subPipe(split.Left, split.Right, builder, false)
-	} else if slices.Contains(split.Right, "n") && slices.Contains(split.Right, "%") {
-		return subPipe(split.Right, split.Left, builder, true)
 	}
-
-	return test, errors.New("equality test must have 'n' as one of the two tests")
+	if containsSimpleN(left) && slices.Contains(left, "%") {
+		return subPipe(left, right, builder, false)
+	}
+	if containsSimpleN(right) && slices.Contains(right, "%") {
+		return subPipe(right, left, builder, true)
+	}
+	return nil, errors.New("equality test must have 'n' as one of the two tests")
 }
 
 var eqToken eqStruct
@@ -289,104 +356,188 @@ func splitTokens(tokens []string, sep string) (s splitted, err error) {
 	}, nil
 }
 
-// Scan a string for parenthesis
-func scan(s string) <-chan match {
-	ch := make(chan match)
-	go func() {
-		depth := 0
-		opener := 0
-		for index, char := range s {
-			switch char {
-			case '(':
-				if depth == 0 {
-					opener = index
-				}
-				depth++
-			case ')':
-				depth--
-				if depth == 0 {
-					ch <- match{
-						openPos:  opener,
-						closePos: index + 1,
-					}
-				}
-			}
-
+func trimLexicalWhitespace(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return -1
 		}
-		close(ch)
-	}()
-	return ch
+		return r
+	}, s)
 }
 
-// Split the string into tokens
-func split(s string) <-chan string {
-	ch := make(chan string)
-	go func() {
-		s = strings.ReplaceAll(s, " ", "")
-		if !strings.Contains(s, "(") {
-			ch <- s
-		} else {
-			last := 0
-			end := len(s)
-			for info := range scan(s) {
-				if last != info.openPos {
-					ch <- s[last:info.openPos]
-				}
-				ch <- s[info.openPos:info.closePos]
-				last = info.closePos
+func lexicalToken(s string, index int) (token string, next int, err error) {
+	if index >= len(s) {
+		return "", index, errors.New("unexpected end of expression")
+	}
+
+	switch s[index] {
+	case '?', ':', '%', '(', ')':
+		return s[index : index+1], index + 1, nil
+	case '|':
+		if index+1 >= len(s) || s[index+1] != '|' {
+			return "", index, errors.New("logical OR must use '||'")
+		}
+		return "||", index + 2, nil
+	case '&':
+		if index+1 >= len(s) || s[index+1] != '&' {
+			return "", index, errors.New("logical AND must use '&&'")
+		}
+		return "&&", index + 2, nil
+	case '=':
+		if index+1 >= len(s) || s[index+1] != '=' {
+			return "", index, errors.New("equality must use '=='")
+		}
+		return "==", index + 2, nil
+	case '!':
+		if index+1 >= len(s) || s[index+1] != '=' {
+			return "", index, errors.New("inequality must use '!='")
+		}
+		return "!=", index + 2, nil
+	case '>':
+		if index+1 < len(s) && s[index+1] == '=' {
+			return ">=", index + 2, nil
+		}
+		return ">", index + 1, nil
+	case '<':
+		if index+1 < len(s) && s[index+1] == '=' {
+			return "<=", index + 2, nil
+		}
+		return "<", index + 1, nil
+	case 'n':
+		return "n", index + 1, nil
+	default:
+		if s[index] >= '0' && s[index] <= '9' {
+			next = index + 1
+			for next < len(s) && s[next] >= '0' && s[next] <= '9' {
+				next++
 			}
-			if last != end {
-				ch <- s[last:]
+			return s[index:next], next, nil
+		}
+		return "", index, fmt.Errorf("invalid character %q in expression", s[index])
+	}
+}
+
+func validateParentheses(s string) error {
+	depth := 0
+	for index := 0; index < len(s); {
+		token, next, err := lexicalToken(s, index)
+		if err != nil {
+			return err
+		}
+		switch token {
+		case "(":
+			depth++
+		case ")":
+			depth--
+			if depth < 0 {
+				return errors.New("unmatched closing parenthesis")
 			}
 		}
-		close(ch)
-	}()
-	return ch
+		index = next
+	}
+	if depth != 0 {
+		return errors.New("unmatched opening parenthesis")
+	}
+	return nil
+}
+
+func stripRedundantOuterParens(s string) string {
+	if len(s) < 2 || s[0] != '(' {
+		return s
+	}
+
+	leading := 0
+	for leading < len(s) && s[leading] == '(' {
+		leading++
+	}
+
+	openers := make([]int, 0, leading)
+	outer := leading
+	for index := range s {
+		switch s[index] {
+		case '(':
+			openers = append(openers, index)
+		case ')':
+			if len(openers) == 0 {
+				return s
+			}
+			opener := openers[len(openers)-1]
+			openers = openers[:len(openers)-1]
+			if opener < outer && index != len(s)-1-opener {
+				outer = opener
+			}
+		}
+	}
+	if len(openers) != 0 {
+		return s
+	}
+	return s[outer : len(s)-outer]
 }
 
 // Tokenizes a string into a list of strings, tokens grouped by parenthesis are
 // not split! If the string starts with ( and ends in ), those are stripped.
 func tokenize(s string) ([]string, error) {
-	/*
-		TODO: Properly detect if the string starts with a ( and ends with a )
-		and that those two form a matching pair.
-
-		Eg: (foo) -> true; (foo)(bar) -> false;
-	*/
-	if len(s) == 0 {
+	s = trimLexicalWhitespace(s)
+	if s == "" {
 		return []string{}, nil
 	}
-	if s[0] == '(' && s[len(s)-1] == ')' {
-		s = s[1 : len(s)-1]
+	if err := validateParentheses(s); err != nil {
+		return nil, err
 	}
+	s = stripRedundantOuterParens(s)
+	if s == "" {
+		return []string{}, nil
+	}
+
 	ret := []string{}
-	for chunk := range split(s) {
-		if len(chunk) != 0 {
-			if chunk[0] == '(' && chunk[len(chunk)-1] == ')' {
-				ret = append(ret, chunk)
-			} else {
-				// Verify all characters in chunk are matched by our pattern
-				matches := pat.FindAllStringSubmatch(chunk, -1)
-				matchedLen := 0
-				for _, token := range matches {
-					ret = append(ret, token[0])
-					matchedLen += len(token[0])
+	for index := 0; index < len(s); {
+		if s[index] == '(' {
+			start := index
+			depth := 0
+			groupEnd := false
+			for index < len(s) {
+				switch s[index] {
+				case '(':
+					depth++
+				case ')':
+					depth--
+					if depth == 0 {
+						index++
+						ret = append(ret, s[start:index])
+						groupEnd = true
+					}
 				}
-				if matchedLen != len(chunk) {
-					return nil, fmt.Errorf("invalid character in expression chunk: %s", chunk)
+				if groupEnd {
+					break
 				}
+				index++
 			}
-		} else {
-			fmt.Printf("Empty chunk in string '%s'\n", s)
+			if depth != 0 {
+				return nil, errors.New("unmatched opening parenthesis")
+			}
+			continue
 		}
+		token, next, err := lexicalToken(s, index)
+		if err != nil {
+			return nil, err
+		}
+		if token == ")" {
+			return nil, errors.New("unmatched closing parenthesis")
+		}
+		ret = append(ret, token)
+		index = next
 	}
 	return ret, nil
 }
 
 // Compile a string containing a plural form expression to a Expression object.
 func Compile(s string) (expr Expression, err error) {
+	s = trimLexicalWhitespace(s)
 	if s == "0" {
 		return constValue{value: 0}, nil
+	}
+	if s == "" {
+		return nil, errors.New("empty expression")
 	}
 	if !strings.Contains(s, "?") {
 		s += "?1:0"
@@ -396,25 +547,42 @@ func Compile(s string) (expr Expression, err error) {
 
 // Compiles an expression (ternary or constant)
 func compileExpression(s string) (expr Expression, err error) {
+	return compileExpressionDepth(s, 0)
+}
+
+func compileExpressionDepth(s string, depth int) (expr Expression, err error) {
+	if depth > maxParseDepth {
+		return nil, errors.New("expression nesting is too deep")
+	}
 	tokens, err := tokenize(s)
 	if err != nil {
 		return nil, err
 	}
 	if slices.Contains(tokens, "?") {
-		return ternaryToken.compile(tokens)
+		return compileTernary(tokens, depth)
 	}
 	return constToken.compile(tokens)
-
 }
 
 // Compiles a test (comparison)
-func compileTest(s string) (test test, err error) {
+func compileTestDepth(s string, depth int) (test test, err error) {
+	if depth > maxParseDepth {
+		return nil, errors.New("expression nesting is too deep")
+	}
 	tokens, err := tokenize(s)
 	if err != nil {
 		return nil, err
 	}
 	for _, tokenDef := range precedence {
-		if slices.Contains(tokens, tokenDef.op) {
+		if !slices.Contains(tokens, tokenDef.op) {
+			continue
+		}
+		switch tokenDef.op {
+		case "||":
+			return compileLogicTestDepth(tokens, "||", buildOr, depth)
+		case "&&":
+			return compileLogicTestDepth(tokens, "&&", buildAnd, depth)
+		default:
 			return tokenDef.token.compile(tokens)
 		}
 	}
@@ -428,13 +596,24 @@ func compileTest(s string) (test test, err error) {
 			action:   equal{value: 0}, // default to testing for 0
 		}, nil
 	}
+	if len(tokens) == 1 && strings.HasPrefix(tokens[0], "(") {
+		inner, err := tokenize(tokens[0])
+		if err != nil {
+			return nil, err
+		}
+		if len(inner) == 1 && inner[0] == tokens[0] {
+			return nil, errors.New("cannot compile parenthesized test")
+		}
+		return compileTestDepth(tokens[0], depth+1)
+	}
 	if len(tokens) == 1 && tokens[0] == "n" {
 		return equal{value: 1}, nil
 	}
-	return test, errors.New("cannot compile")
+	return nil, errors.New("cannot compile")
 }
 
 func parseUint32(s string) (ui uint32, err error) {
+	s = trimLexicalWhitespace(s)
 	i, err := strconv.ParseUint(s, 10, 32)
 	if err != nil {
 		return ui, err

--- a/plurals/compiler.go
+++ b/plurals/compiler.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -54,7 +55,7 @@ func (ternaryStruct) compile(tokens []string) (expr Expression, err error) {
 	}
 	falseAction, err := compileExpression(strings.Join(actions.Right, ""))
 	if err != nil {
-		return expr, nil
+		return expr, err
 	}
 	return ternary{
 		test:      test,
@@ -134,6 +135,9 @@ func compileMod(tokens []string) (math math, err error) {
 	if err != nil {
 		return math, err
 	}
+	if i == 0 {
+		return math, errors.New("modulus operation requires a non-zero integer as right operand")
+	}
 	return mod{value: uint32(i)}, nil
 }
 
@@ -161,7 +165,7 @@ func compileEquality(tokens []string, sep string, builder cmpTestBuilder) (test 
 	if err != nil {
 		return test, err
 	}
-	if contains(split.Left, "n") && !contains(split.Left, "%") && len(split.Left) == 1 {
+	if slices.Contains(split.Left, "n") && !slices.Contains(split.Left, "%") && len(split.Left) == 1 {
 		i, err := parseUint32(strings.Join(split.Right, ""))
 		if err != nil {
 			// Try to compile it as a full expression if it's not a simple integer
@@ -170,15 +174,15 @@ func compileEquality(tokens []string, sep string, builder cmpTestBuilder) (test 
 			return test, err
 		}
 		return builder(i, false), nil
-	} else if contains(split.Right, "n") && !contains(split.Right, "%") && len(split.Right) == 1 {
+	} else if slices.Contains(split.Right, "n") && !slices.Contains(split.Right, "%") && len(split.Right) == 1 {
 		i, err := parseUint32(strings.Join(split.Left, ""))
 		if err != nil {
 			return test, err
 		}
 		return builder(i, true), nil
-	} else if contains(split.Left, "n") && contains(split.Left, "%") {
+	} else if slices.Contains(split.Left, "n") && slices.Contains(split.Left, "%") {
 		return subPipe(split.Left, split.Right, builder, false)
-	} else if contains(split.Right, "n") && contains(split.Right, "%") {
+	} else if slices.Contains(split.Right, "n") && slices.Contains(split.Right, "%") {
 		return subPipe(split.Right, split.Left, builder, true)
 	}
 
@@ -272,20 +276,10 @@ type splitted struct {
 	Right []string
 }
 
-// Find index of token in list of tokens
-func index(tokens []string, sep string) int {
-	for index, token := range tokens {
-		if token == sep {
-			return index
-		}
-	}
-	return -1
-}
-
 // Split a list of tokens by a token into a splitted struct holding the tokens
 // before and after the token to be split by.
 func splitTokens(tokens []string, sep string) (s splitted, err error) {
-	index := index(tokens, sep)
+	index := slices.Index(tokens, sep)
 	if index == -1 {
 		return s, fmt.Errorf("'%s' not found in ['%s']", sep, strings.Join(tokens, "','"))
 	}
@@ -400,26 +394,17 @@ func Compile(s string) (expr Expression, err error) {
 	return compileExpression(s)
 }
 
-// Check if a token is in a slice of strings
-func contains(haystack []string, needle string) bool {
-	for _, s := range haystack {
-		if s == needle {
-			return true
-		}
-	}
-	return false
-}
-
 // Compiles an expression (ternary or constant)
 func compileExpression(s string) (expr Expression, err error) {
 	tokens, err := tokenize(s)
 	if err != nil {
 		return nil, err
 	}
-	if contains(tokens, "?") {
+	if slices.Contains(tokens, "?") {
 		return ternaryToken.compile(tokens)
 	}
 	return constToken.compile(tokens)
+
 }
 
 // Compiles a test (comparison)
@@ -429,11 +414,11 @@ func compileTest(s string) (test test, err error) {
 		return nil, err
 	}
 	for _, tokenDef := range precedence {
-		if contains(tokens, tokenDef.op) {
+		if slices.Contains(tokens, tokenDef.op) {
 			return tokenDef.token.compile(tokens)
 		}
 	}
-	if contains(tokens, "%") {
+	if slices.Contains(tokens, "%") {
 		m, err := compileMod(tokens)
 		if err != nil {
 			return nil, err

--- a/plurals/compiler_test.go
+++ b/plurals/compiler_test.go
@@ -71,14 +71,32 @@ func TestCompile_EdgeCases(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for malformed ternary")
 	}
+	// Malformed false branch
+	expr, err = Compile("n == 1 ? 0 :")
+	if err == nil {
+		t.Error("Expected error for malformed false branch")
+	}
+	if expr != nil {
+		t.Error("Expected nil expression for malformed false branch")
+	}
 
 	// Unexpected EOF in logic test
 	_, err = Compile("n >")
 	if err == nil {
 		t.Error("Expected error for unexpected EOF")
 	}
+	// Zero modulus
+	for _, expression := range []string{"n % 0", "n % 0 == 0"} {
+		expr, err = Compile(expression)
+		if err == nil {
+			t.Errorf("Expected error for zero modulus expression %q", expression)
+		}
+		if expr != nil {
+			t.Errorf("Expected nil expression for zero modulus expression %q", expression)
+		}
+	}
 
-	// Missing closing parenthesis - current compiler might not catch this strictly, 
+	// Missing closing parenthesis - current compiler might not catch this strictly,
 	// or it catches it in a way that doesn't return an error immediately from Compile.
 	// Let's remove it if it doesn't fail, or just focus on what DOES fail.
 }
@@ -114,7 +132,7 @@ func TestEval_EdgeCases(t *testing.T) {
 		{"n < 2", 1, 1},
 		{"n >= 1", 1, 1},
 		{"n <= 1", 1, 1},
-		{"n % 10", 3, 0}, // n % 10 == 0? 3 % 10 is 3, so false (0)
+		{"n % 10", 3, 0},  // n % 10 == 0? 3 % 10 is 3, so false (0)
 		{"n % 10", 10, 1}, // 10 % 10 is 0, so true (1)
 		{"n % 10 == 3", 3, 1},
 		{"n % 10 == 3", 13, 1},

--- a/plurals/compiler_test.go
+++ b/plurals/compiler_test.go
@@ -8,7 +8,6 @@ package plurals
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -25,194 +24,71 @@ func TestCompiler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dec := json.NewDecoder(f)
+	t.Cleanup(func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("close plural forms fixture: %v", err)
+		}
+	})
+
 	var fixtures []fixture
-	err = dec.Decode(&fixtures)
-	if err != nil {
+	if err := json.NewDecoder(f).Decode(&fixtures); err != nil {
 		t.Fatal(err)
 	}
 	for _, data := range fixtures {
-		expr, err := Compile(data.PluralForm)
-		if err != nil {
-			t.Errorf("'%s' triggered error: %s", data.PluralForm, err)
-		} else if expr == nil {
-			t.Logf("'%s' compiled to nil", data.PluralForm)
-			t.Fail()
-		} else {
-			for n, e := range data.Fixture {
-				i := expr.Eval(uint32(n))
-				if i != e {
-					t.Logf("'%s' with n = %d, expected %d, got %d, compiled to %s", data.PluralForm, n, e, i, expr)
-					t.Fail()
-				}
-				if i == -1 {
-					break
+		data := data
+		t.Run(data.PluralForm, func(t *testing.T) {
+			expr, err := Compile(data.PluralForm)
+			if err != nil {
+				t.Fatalf("Compile(%q) failed: %v", data.PluralForm, err)
+			}
+			if expr == nil {
+				t.Fatalf("Compile(%q) returned a nil expression", data.PluralForm)
+			}
+			for n, want := range data.Fixture {
+				if got := expr.Eval(uint32(n)); got != want {
+					t.Errorf("Eval(%q, %d) = %d, want %d", data.PluralForm, n, got, want)
 				}
 			}
-		}
+		})
 	}
 }
 
-func TestCompile_EdgeCases(t *testing.T) {
-	// Empty expression
-	expr, err := Compile("")
-	if err == nil {
-		t.Error("Expected error for empty expression")
-	}
-	if expr != nil {
-		t.Error("Expected nil expression for error")
-	}
-
-	// Invalid tokens
-	_, err = Compile("n + @")
-	if err == nil {
-		t.Error("Expected error for invalid token")
-	}
-
-	// Malformed ternary
-	_, err = Compile("n ? 1")
-	if err == nil {
-		t.Error("Expected error for malformed ternary")
-	}
-	// Malformed false branch
-	expr, err = Compile("n == 1 ? 0 :")
-	if err == nil {
-		t.Error("Expected error for malformed false branch")
-	}
-	if expr != nil {
-		t.Error("Expected nil expression for malformed false branch")
-	}
-
-	// Unexpected EOF in logic test
-	_, err = Compile("n >")
-	if err == nil {
-		t.Error("Expected error for unexpected EOF")
-	}
-	// Zero modulus
-	for _, expression := range []string{"n % 0", "n % 0 == 0"} {
-		expr, err = Compile(expression)
-		if err == nil {
-			t.Errorf("Expected error for zero modulus expression %q", expression)
-		}
-		if expr != nil {
-			t.Errorf("Expected nil expression for zero modulus expression %q", expression)
-		}
-	}
-
-	// Missing closing parenthesis - current compiler might not catch this strictly,
-	// or it catches it in a way that doesn't return an error immediately from Compile.
-	// Let's remove it if it doesn't fail, or just focus on what DOES fail.
-}
-
-func TestCompile_LogicCoverage(t *testing.T) {
-	// Covering more branches in compileLogicTest and others
-	tests := []string{
-		"n >= 1",
-		"n <= 1",
-		"n % 10 == 1",
-		"n == 1 ? 0 : n == 2 ? 1 : 2",
-	}
-	for _, tt := range tests {
-		_, err := Compile(tt)
-		if err != nil {
-			t.Errorf("Compile(%q) failed: %v", tt, err)
-		}
-	}
-}
-
-func TestEval_EdgeCases(t *testing.T) {
-	// Covering eval with different operators
-	tests := []struct {
-		expr string
-		n    uint32
-		want int
-	}{
-		{"n == 1", 1, 1},
-		{"n == 1", 2, 0},
-		{"n != 1", 1, 0},
-		{"n != 1", 2, 1},
-		{"n > 1", 2, 1},
-		{"n < 2", 1, 1},
-		{"n >= 1", 1, 1},
-		{"n <= 1", 1, 1},
-		{"n % 10", 3, 0},  // n % 10 == 0? 3 % 10 is 3, so false (0)
-		{"n % 10", 10, 1}, // 10 % 10 is 0, so true (1)
-		{"n % 10 == 3", 3, 1},
-		{"n % 10 == 3", 13, 1},
-		{"n % 10 == 3", 4, 0},
-		{"3 == n % 10", 3, 1}, // Test flipped side
-		// Asian (1 form)
-		{"0", 1, 0},
-		{"0", 10, 0},
-		// Germanic/Latin (2 forms)
-		{"n != 1", 1, 0},
-		{"n != 1", 2, 1},
-		// French (2 forms)
-		{"n > 1", 1, 0},
-		{"n > 1", 2, 1},
-		// Celtic (5 forms)
-		{"n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4", 1, 0},
-		{"n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4", 2, 1},
-		{"n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4", 5, 2},
-		{"n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4", 10, 3},
-		{"n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4", 11, 4},
-		// Slavic-like (nested conditions with AND/OR)
-		{"n%10==1 && n%100!=11 ? 0 : 1", 1, 0},
-		{"n%10==1 && n%100!=11 ? 0 : 1", 11, 1},
-		{"n%10==1 && n%100!=11 ? 0 : 1", 21, 0},
-		// Baltic (3 forms)
-		{"n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2", 1, 0},
-		{"n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2", 2, 1},
-		{"n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2", 0, 2},
-		// Arabic (6 forms)
-		{"n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5", 0, 0},
-		{"n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5", 1, 1},
-		{"n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5", 2, 2},
-		{"n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5", 3, 3},
-		{"n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5", 10, 3},
-		{"n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5", 11, 4},
-		{"n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5", 99, 4},
-		{"n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5", 100, 5},
-		// Slavic (3 forms) - using parentheses
-		{"n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2", 1, 0},
-		{"n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2", 2, 1},
-		{"n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2", 5, 2},
-		{"n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2", 11, 2},
-		{"n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2", 22, 1},
-	}
-	for _, tt := range tests {
-		expr, err := Compile(tt.expr)
-		if err != nil {
-			t.Errorf("Compile(%q) failed: %v", tt.expr, err)
-			continue
-		}
-		if got := expr.Eval(tt.n); got != tt.want {
-			t.Errorf("Eval(%q, %d) = %d, want %d", tt.expr, tt.n, got, tt.want)
-		}
-	}
-}
-
-func TestCompile_ParenthesesAndAssociativity(t *testing.T) {
+func TestCompileEvalGNUExpressions(t *testing.T) {
 	tests := []struct {
 		name string
 		expr string
 		n    uint32
 		want int
 	}{
-		{name: "independent parenthesized operands", expr: "(n==1)||(n==2)", n: 1, want: 1},
-		{name: "independent parenthesized operands second", expr: "(n==1)||(n==2)", n: 2, want: 1},
-		{name: "independent parenthesized operands neither", expr: "(n==1)||(n==2)", n: 3, want: 0},
-		{name: "redundant nesting", expr: "((((n==1))))", n: 1, want: 1},
-		{name: "redundant nesting false", expr: "((((n==1))))", n: 2, want: 0},
-		{name: "nested ternary in true arm", expr: "n==1 ? n==2 ? 10 : 11 : 12", n: 1, want: 11},
-		{name: "nested ternary outer false", expr: "n==1 ? n==2 ? 10 : 11 : 12", n: 2, want: 12},
-		{name: "nested ternary nested true arm", expr: "n==1 ? n==2 ? 10 : n==3 ? 11 : 12 : 13", n: 1, want: 12},
-		{name: "established nested parenthesized test zero", expr: "n==1?0:(n==0||(n%100>0&&n%100<20))?1:2", n: 0, want: 1},
-		{name: "established nested parenthesized test one", expr: "n==1?0:(n==0||(n%100>0&&n%100<20))?1:2", n: 1, want: 0},
-		{name: "established nested parenthesized test teen", expr: "n==1?0:(n==0||(n%100>0&&n%100<20))?1:2", n: 19, want: 1},
-		{name: "established nested parenthesized test outside range", expr: "n==1?0:(n==0||(n%100>0&&n%100<20))?1:2", n: 20, want: 2},
+		{name: "implicit equality true", expr: "n", n: 1, want: 1},
+		{name: "implicit equality false", expr: "n", n: 2, want: 0},
+		{name: "equality true", expr: "n == 1", n: 1, want: 1},
+		{name: "equality false", expr: "n == 1", n: 2, want: 0},
+		{name: "inequality true", expr: "n != 1", n: 2, want: 1},
+		{name: "inequality false", expr: "n != 1", n: 1, want: 0},
+		{name: "greater true", expr: "n > 1", n: 2, want: 1},
+		{name: "greater false", expr: "n > 1", n: 1, want: 0},
+		{name: "greater equal boundary", expr: "n >= 1", n: 1, want: 1},
+		{name: "greater equal false", expr: "n >= 1", n: 0, want: 0},
+		{name: "less true", expr: "n < 2", n: 1, want: 1},
+		{name: "less false", expr: "n < 2", n: 2, want: 0},
+		{name: "less equal boundary", expr: "n <= 1", n: 1, want: 1},
+		{name: "less equal false", expr: "n <= 1", n: 2, want: 0},
+		{name: "modulo default true", expr: "n % 10", n: 10, want: 1},
+		{name: "modulo default false", expr: "n % 10", n: 3, want: 0},
+		{name: "modulo equality", expr: "n % 10 == 3", n: 13, want: 1},
+		{name: "modulo equality false", expr: "n % 10 == 3", n: 14, want: 0},
+		{name: "reversed modulo equality", expr: "3 == n % 10", n: 13, want: 1},
+		{name: "reversed modulo inequality", expr: "3 != n % 10", n: 13, want: 0},
+		{name: "simple ternary true", expr: "n == 1 ? 7 : 9", n: 1, want: 7},
+		{name: "simple ternary false", expr: "n == 1 ? 7 : 9", n: 2, want: 9},
+		{name: "nested ternary inner true", expr: "n < 3 ? n == 2 ? 10 : 11 : 12", n: 2, want: 10},
+		{name: "nested ternary inner false", expr: "n < 3 ? n == 2 ? 10 : 11 : 12", n: 1, want: 11},
+		{name: "nested ternary outer false", expr: "n < 3 ? n == 2 ? 10 : 11 : 12", n: 3, want: 12},
+		{name: "nested false arm", expr: "n == 0 ? 0 : n == 1 ? 1 : 2", n: 2, want: 2},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			expr, err := Compile(tt.expr)
 			if err != nil {
@@ -228,9 +104,150 @@ func TestCompile_ParenthesesAndAssociativity(t *testing.T) {
 	}
 }
 
-func TestCompile_WhitespaceAndPrecedence(t *testing.T) {
+func TestCompileEvalPrecedenceAndParentheses(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+		n    uint32
+		want int
+	}{
+		{
+			name: "and binds tighter than or, left branch",
+			expr: "n == 1 || n == 2 && n != 1 ? 1 : 0",
+			n:    1,
+			want: 1,
+		},
+		{
+			name: "and binds tighter than or, right branch",
+			expr: "n == 1 || n == 2 && n != 1 ? 1 : 0",
+			n:    2,
+			want: 1,
+		},
+		{
+			name: "and binds tighter than or, neither branch",
+			expr: "n == 1 || n == 2 && n != 1 ? 1 : 0",
+			n:    3,
+			want: 0,
+		},
+		{
+			name: "or follows and",
+			expr: "n == 1 && n != 2 || n == 3 ? 1 : 0",
+			n:    3,
+			want: 1,
+		},
+		{
+			name: "parentheses override and-or precedence",
+			expr: "(n == 1 || n == 2) && n != 1 ? 1 : 0",
+			n:    1,
+			want: 0,
+		},
+		{
+			name: "parentheses preserve selected branch",
+			expr: "(n == 1 || n == 2) && n != 1 ? 1 : 0",
+			n:    2,
+			want: 1,
+		},
+		{
+			name: "nested parenthesized plural rule zero",
+			expr: "n == 1 ? 0 : (n == 0 || (n % 100 > 0 && n % 100 < 20)) ? 1 : 2",
+			n:    0,
+			want: 1,
+		},
+		{
+			name: "nested parenthesized plural rule one",
+			expr: "n == 1 ? 0 : (n == 0 || (n % 100 > 0 && n % 100 < 20)) ? 1 : 2",
+			n:    1,
+			want: 0,
+		},
+		{
+			name: "nested parenthesized plural rule teen",
+			expr: "n == 1 ? 0 : (n == 0 || (n % 100 > 0 && n % 100 < 20)) ? 1 : 2",
+			n:    19,
+			want: 1,
+		},
+		{
+			name: "nested parenthesized plural rule outside range",
+			expr: "n == 1 ? 0 : (n == 0 || (n % 100 > 0 && n % 100 < 20)) ? 1 : 2",
+			n:    20,
+			want: 2,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			expr, err := Compile(tt.expr)
+			if err != nil {
+				t.Fatalf("Compile(%q) failed: %v", tt.expr, err)
+			}
+			if expr == nil {
+				t.Fatalf("Compile(%q) returned a nil expression", tt.expr)
+			}
+			if got := expr.Eval(tt.n); got != tt.want {
+				t.Errorf("Eval(%q, %d) = %d, want %d", tt.expr, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompileEvalLogicalShortCircuitCases(t *testing.T) {
+	// GNU plural expressions are side-effect free, so the source-level
+	// short-circuit contract is checked against native Go boolean semantics.
+	tests := []struct {
+		name string
+		expr string
+		n    uint32
+		want func(uint32) bool
+	}{
+		{
+			name: "false and",
+			expr: "n == 0 && n % 10 == 0 ? 1 : 0",
+			n:    1,
+			want: func(n uint32) bool { return n == 0 && n%10 == 0 },
+		},
+		{
+			name: "true and with false right side",
+			expr: "n == 1 && n % 10 == 0 ? 1 : 0",
+			n:    1,
+			want: func(n uint32) bool { return n == 1 && n%10 == 0 },
+		},
+		{
+			name: "true or",
+			expr: "n == 1 || n % 10 == 0 ? 1 : 0",
+			n:    1,
+			want: func(n uint32) bool { return n == 1 || n%10 == 0 },
+		},
+		{
+			name: "false or with true right side",
+			expr: "n == 1 || n % 10 == 0 ? 1 : 0",
+			n:    10,
+			want: func(n uint32) bool { return n == 1 || n%10 == 0 },
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			expr, err := Compile(tt.expr)
+			if err != nil {
+				t.Fatalf("Compile(%q) failed: %v", tt.expr, err)
+			}
+			if expr == nil {
+				t.Fatalf("Compile(%q) returned a nil expression", tt.expr)
+			}
+			want := 0
+			if tt.want(tt.n) {
+				want = 1
+			}
+			if got := expr.Eval(tt.n); got != want {
+				t.Errorf("Eval(%q, %d) = %d, want %d", tt.expr, tt.n, got, want)
+			}
+		})
+	}
+}
+
+func TestCompileEvalWhitespaceAndUint32Boundaries(t *testing.T) {
 	for _, input := range []string{" 0 ", "\t0\n", "\u20030\u2003"} {
-		t.Run(fmt.Sprintf("zero_%q", input), func(t *testing.T) {
+		input := input
+		t.Run("constant whitespace", func(t *testing.T) {
 			expr, err := Compile(input)
 			if err != nil {
 				t.Fatalf("Compile(%q) failed: %v", input, err)
@@ -244,51 +261,33 @@ func TestCompile_WhitespaceAndPrecedence(t *testing.T) {
 		})
 	}
 
+	const maxUint32 = ^uint32(0)
+	maxLiteral := strconv.FormatUint(uint64(maxUint32), 10)
 	tests := []struct {
 		name string
 		expr string
 		n    uint32
 		want int
 	}{
-		{name: "and binds tighter than or", expr: "n==1 || n==2 && n==3 ? 1 : 0", n: 1, want: 1},
-		{name: "and binds tighter than or false", expr: "n==1 || n==2 && n==3 ? 1 : 0", n: 2, want: 0},
-		{name: "and binds tighter than or right", expr: "n==1 && n==2 || n==3 ? 1 : 0", n: 3, want: 1},
-		{name: "and binds tighter than or right false", expr: "n==1 && n==2 || n==3 ? 1 : 0", n: 1, want: 0},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			expr, err := Compile(tt.expr)
-			if err != nil {
-				t.Fatalf("Compile(%q) failed: %v", tt.expr, err)
-			}
-			if got := expr.Eval(tt.n); got != tt.want {
-				t.Errorf("Eval(%q, %d) = %d, want %d", tt.expr, tt.n, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestCompile_ReversedRelationalAndUint32Boundaries(t *testing.T) {
-	tests := []struct {
-		name string
-		expr string
-		n    uint32
-		want int
-	}{
-		{name: "reversed greater", expr: "1 > n", n: 0, want: 1},
+		{name: "reversed greater true", expr: "1 > n", n: 0, want: 1},
 		{name: "reversed greater false", expr: "1 > n", n: 1, want: 0},
 		{name: "reversed greater equal", expr: "1 >= n", n: 1, want: 1},
-		{name: "reversed less", expr: "1 < n", n: 2, want: 1},
+		{name: "reversed less true", expr: "1 < n", n: 2, want: 1},
 		{name: "reversed less false", expr: "1 < n", n: 1, want: 0},
 		{name: "reversed less equal", expr: "1 <= n", n: 1, want: 1},
-		{name: "maximum equality", expr: "n == 4294967295", n: ^uint32(0), want: 1},
-		{name: "maximum modulo", expr: "n % 4294967295 == 0", n: ^uint32(0), want: 1},
+		{name: "maximum equality", expr: "n == " + maxLiteral, n: maxUint32, want: 1},
+		{name: "maximum equality false", expr: "n == " + maxLiteral, n: maxUint32 - 1, want: 0},
+		{name: "maximum modulo remainder", expr: "n % " + maxLiteral + " == 0", n: maxUint32, want: 1},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			expr, err := Compile(tt.expr)
 			if err != nil {
 				t.Fatalf("Compile(%q) failed: %v", tt.expr, err)
+			}
+			if expr == nil {
+				t.Fatalf("Compile(%q) returned a nil expression", tt.expr)
 			}
 			if got := expr.Eval(tt.n); got != tt.want {
 				t.Errorf("Eval(%q, %d) = %d, want %d", tt.expr, tt.n, got, tt.want)
@@ -297,10 +296,10 @@ func TestCompile_ReversedRelationalAndUint32Boundaries(t *testing.T) {
 	}
 }
 
-func TestCompile_ResultLiteralIntRange(t *testing.T) {
+func TestCompileResultLiteralIntRange(t *testing.T) {
 	maxInt := int(^uint(0) >> 1)
 	maxIntLiteral := strconv.FormatInt(int64(maxInt), 10)
-	expr, err := Compile("n==1?" + maxIntLiteral + ":0")
+	expr, err := Compile("n == 1 ? " + maxIntLiteral + " : 0")
 	if err != nil {
 		t.Fatalf("Compile(max-int result literal) failed: %v", err)
 	}
@@ -310,9 +309,12 @@ func TestCompile_ResultLiteralIntRange(t *testing.T) {
 	if got := expr.Eval(1); got != maxInt {
 		t.Errorf("Eval(max-int result literal, 1) = %d, want %d", got, maxInt)
 	}
+	if got := expr.Eval(2); got != 0 {
+		t.Errorf("Eval(max-int result literal, 2) = %d, want 0", got)
+	}
 
 	overflowLiteral := strconv.FormatUint(uint64(maxInt)+1, 10)
-	expr, err = Compile("n==1?" + overflowLiteral + ":0")
+	expr, err = Compile("n == 1 ? " + overflowLiteral + " : 0")
 	if err == nil {
 		t.Error("Compile(result literal above max int) returned no error")
 	}
@@ -321,9 +323,9 @@ func TestCompile_ResultLiteralIntRange(t *testing.T) {
 	}
 }
 
-func TestCompile_DeeplyNestedParentheses(t *testing.T) {
+func TestCompileDeeplyNestedParentheses(t *testing.T) {
 	const depth = 32 * 1024
-	input := strings.Repeat("(", depth) + "n==1" + strings.Repeat(")", depth)
+	input := strings.Repeat("(", depth) + "n == 1" + strings.Repeat(")", depth)
 
 	expr, err := Compile(input)
 	if err != nil {
@@ -340,102 +342,60 @@ func TestCompile_DeeplyNestedParentheses(t *testing.T) {
 	}
 }
 
-func TestCompile_MalformedExpressionsReturnNil(t *testing.T) {
+func TestCompileMalformedExpressionsReturnNil(t *testing.T) {
+	maxUint32 := ^uint32(0)
+	aboveUint32 := strconv.FormatUint(uint64(maxUint32)+1, 10)
 	maxInt := int(^uint(0) >> 1)
-	overflowLiteral := strconv.FormatUint(uint64(maxInt)+1, 10)
-	expressions := []string{
-		"",
-		"?1:0",
-		"n==1?:0",
-		"n==1?0:",
-		"n==1?",
-		"n==1:0",
-		"n==1??0:1",
-		"n==1?0::1",
-		"n==1?0:1:2",
-		"n==1&&",
-		"n==1||",
-		"n==1&&&&n==2",
-		"n==1||||n==2",
-		"n==1&&||n==2",
-		"n+@",
-		"n&1",
-		"n|1",
-		"n==1)",
-		"(n==1",
-		"((n==1)",
-		"n==4294967296",
-		"n%4294967296==0",
-		"n==1?" + overflowLiteral + ":0",
+	aboveMaxInt := strconv.FormatUint(uint64(maxInt)+1, 10)
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{name: "empty expression", expr: ""},
+		{name: "missing ternary condition", expr: "?1:0"},
+		{name: "missing true branch", expr: "n == 1 ? : 0"},
+		{name: "missing false branch", expr: "n == 1 ? 0 :"},
+		{name: "missing ternary colon", expr: "n == 1 ?"},
+		{name: "colon without ternary", expr: "n == 1 : 0"},
+		{name: "nested ternary missing true branch", expr: "n == 1 ? ?0:1"},
+		{name: "nested ternary extra colon", expr: "n == 1 ? 0::1"},
+		{name: "extra ternary branch", expr: "n == 1 ? 0 : 1 : 2"},
+		{name: "missing and operand", expr: "n == 1 &&"},
+		{name: "missing or operand", expr: "n == 1 ||"},
+		{name: "repeated and operator", expr: "n == 1 &&&& n == 2"},
+		{name: "repeated or operator", expr: "n == 1 |||| n == 2"},
+		{name: "mixed logical operators", expr: "n == 1 && || n == 2"},
+		{name: "invalid character", expr: "n + @"},
+		{name: "single ampersand", expr: "n&1"},
+		{name: "single pipe", expr: "n|1"},
+		{name: "unmatched closing parenthesis", expr: "n == 1)"},
+		{name: "unmatched opening parenthesis", expr: "(n == 1"},
+		{name: "multiple unmatched opening parentheses", expr: "((n == 1)"},
+		{name: "uint32 literal overflow", expr: "n == " + aboveUint32},
+		{name: "modulus literal overflow", expr: "n % " + aboveUint32 + " == 0"},
+		{name: "zero modulus", expr: "n % 0"},
+		{name: "zero modulus comparison", expr: "n % 0 == 0"},
+		{name: "missing modulus right operand", expr: "n %"},
+		{name: "comparison without n", expr: "1 == 2"},
+		{name: "comparison of two n values", expr: "n == n"},
+		{name: "result literal overflow", expr: "n == 1 ? " + aboveMaxInt + " : 0"},
 	}
-	for _, input := range expressions {
-		t.Run(fmt.Sprintf("malformed_%q", input), func(t *testing.T) {
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
 			defer func() {
 				if recovered := recover(); recovered != nil {
-					t.Fatalf("Compile(%q) panicked: %v", input, recovered)
+					t.Fatalf("Compile(%q) panicked: %v", tt.expr, recovered)
 				}
 			}()
-			expr, err := Compile(input)
+			expr, err := Compile(tt.expr)
 			if err == nil {
-				t.Fatalf("Compile(%q) returned no error", input)
+				t.Fatalf("Compile(%q) returned no error", tt.expr)
 			}
 			if expr != nil {
-				t.Fatalf("Compile(%q) returned non-nil expression on error", input)
+				t.Fatalf("Compile(%q) returned non-nil expression on error", tt.expr)
 			}
 		})
-	}
-}
-
-type panickingTest struct{}
-
-func (panickingTest) test(uint32) bool {
-	panic("inactive test evaluated")
-}
-
-type panickingExpression struct{}
-
-func (panickingExpression) Eval(uint32) int {
-	panic("inactive expression evaluated")
-}
-
-func TestPluralShortCircuiting(t *testing.T) {
-	if got := (and{left: equal{value: 0}, right: panickingTest{}}).test(1); got {
-		t.Error("and evaluated an inactive right-hand test")
-	}
-	if got := (or{left: equal{value: 1}, right: panickingTest{}}).test(1); !got {
-		t.Error("or did not preserve a true left-hand test")
-	}
-	if got := (ternary{
-		test:      equal{value: 0},
-		trueExpr:  panickingExpression{},
-		falseExpr: constValue{value: 2},
-	}).Eval(1); got != 2 {
-		t.Errorf("ternary selected %d, want 2", got)
-	}
-	if got := (ternary{
-		test:      equal{value: 1},
-		trueExpr:  constValue{value: 3},
-		falseExpr: panickingExpression{},
-	}).Eval(1); got != 3 {
-		t.Errorf("ternary selected %d, want 3", got)
-	}
-}
-
-func TestPluralZeroValues(t *testing.T) {
-	if got := (ternary{}).Eval(0); got != -1 {
-		t.Errorf("zero ternary Eval() = %d, want -1", got)
-	}
-	if got := (and{}).test(0); got {
-		t.Error("zero and test returned true")
-	}
-	if got := (or{}).test(0); got {
-		t.Error("zero or test returned true")
-	}
-	if got := (pipe{}).test(0); got {
-		t.Error("zero pipe test returned true")
-	}
-	if got := (mod{}).calc(7); got != 0 {
-		t.Errorf("zero mod calc() = %d, want 0", got)
 	}
 }
 
@@ -443,26 +403,28 @@ func FuzzCompileEvalNoPanic(f *testing.F) {
 	for _, seed := range []string{
 		"0",
 		" n == 1 ? 0 : 1 ",
-		"(n==1)||(n==2)",
-		"n==1?n==2?1:n==3?2:3:4",
-		"n%4294967295==0",
+		"(n == 1) || (n == 2)",
+		"n == 1 ? n == 2 ? 1 : n == 3 ? 2 : 3 : 4",
+		"n % 4294967295 == 0",
 		"",
-		"n==1&&",
-		"(n==1",
-		"n==4294967296",
+		"n == 1 &&",
+		"(n == 1",
+		"n == 4294967296",
 	} {
 		f.Add(seed)
 	}
 
+	const maxInputBytes = 64 << 10
 	f.Fuzz(func(t *testing.T, input string) {
-		if len(input) > 64<<10 {
+		if len(input) > maxInputBytes {
 			return
 		}
 		defer func() {
 			if recovered := recover(); recovered != nil {
-				t.Fatalf("Compile(%q) panicked: %v", input, recovered)
+				t.Fatalf("Compile/Eval(%q) panicked: %v", input, recovered)
 			}
 		}()
+
 		expr, err := Compile(input)
 		if err != nil {
 			if expr != nil {
@@ -493,11 +455,19 @@ func FuzzModuloComparisonMatchesUint32(f *testing.F) {
 		if divisor == 0 {
 			return
 		}
-		source := fmt.Sprintf("n%%%d==%d", divisor, value)
+
+		// Keep source construction and the oracle in uint32 space. This is
+		// independent of the host int width on both 32-bit and 64-bit Go.
+		source := "n%" + strconv.FormatUint(uint64(divisor), 10) +
+			"==" + strconv.FormatUint(uint64(value), 10)
 		expr, err := Compile(source)
 		if err != nil {
 			t.Fatalf("Compile(%q) failed: %v", source, err)
 		}
+		if expr == nil {
+			t.Fatalf("Compile(%q) returned a nil expression", source)
+		}
+
 		want := 0
 		if n%divisor == value {
 			want = 1

--- a/plurals/compiler_test.go
+++ b/plurals/compiler_test.go
@@ -8,7 +8,10 @@ package plurals
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -187,4 +190,320 @@ func TestEval_EdgeCases(t *testing.T) {
 			t.Errorf("Eval(%q, %d) = %d, want %d", tt.expr, tt.n, got, tt.want)
 		}
 	}
+}
+
+func TestCompile_ParenthesesAndAssociativity(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+		n    uint32
+		want int
+	}{
+		{name: "independent parenthesized operands", expr: "(n==1)||(n==2)", n: 1, want: 1},
+		{name: "independent parenthesized operands second", expr: "(n==1)||(n==2)", n: 2, want: 1},
+		{name: "independent parenthesized operands neither", expr: "(n==1)||(n==2)", n: 3, want: 0},
+		{name: "redundant nesting", expr: "((((n==1))))", n: 1, want: 1},
+		{name: "redundant nesting false", expr: "((((n==1))))", n: 2, want: 0},
+		{name: "nested ternary in true arm", expr: "n==1 ? n==2 ? 10 : 11 : 12", n: 1, want: 11},
+		{name: "nested ternary outer false", expr: "n==1 ? n==2 ? 10 : 11 : 12", n: 2, want: 12},
+		{name: "nested ternary nested true arm", expr: "n==1 ? n==2 ? 10 : n==3 ? 11 : 12 : 13", n: 1, want: 12},
+		{name: "established nested parenthesized test zero", expr: "n==1?0:(n==0||(n%100>0&&n%100<20))?1:2", n: 0, want: 1},
+		{name: "established nested parenthesized test one", expr: "n==1?0:(n==0||(n%100>0&&n%100<20))?1:2", n: 1, want: 0},
+		{name: "established nested parenthesized test teen", expr: "n==1?0:(n==0||(n%100>0&&n%100<20))?1:2", n: 19, want: 1},
+		{name: "established nested parenthesized test outside range", expr: "n==1?0:(n==0||(n%100>0&&n%100<20))?1:2", n: 20, want: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr, err := Compile(tt.expr)
+			if err != nil {
+				t.Fatalf("Compile(%q) failed: %v", tt.expr, err)
+			}
+			if expr == nil {
+				t.Fatalf("Compile(%q) returned a nil expression", tt.expr)
+			}
+			if got := expr.Eval(tt.n); got != tt.want {
+				t.Errorf("Eval(%q, %d) = %d, want %d", tt.expr, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompile_WhitespaceAndPrecedence(t *testing.T) {
+	for _, input := range []string{" 0 ", "\t0\n", "\u20030\u2003"} {
+		t.Run(fmt.Sprintf("zero_%q", input), func(t *testing.T) {
+			expr, err := Compile(input)
+			if err != nil {
+				t.Fatalf("Compile(%q) failed: %v", input, err)
+			}
+			if expr == nil {
+				t.Fatalf("Compile(%q) returned a nil expression", input)
+			}
+			if got := expr.Eval(^uint32(0)); got != 0 {
+				t.Errorf("Eval(%q, max uint32) = %d, want 0", input, got)
+			}
+		})
+	}
+
+	tests := []struct {
+		name string
+		expr string
+		n    uint32
+		want int
+	}{
+		{name: "and binds tighter than or", expr: "n==1 || n==2 && n==3 ? 1 : 0", n: 1, want: 1},
+		{name: "and binds tighter than or false", expr: "n==1 || n==2 && n==3 ? 1 : 0", n: 2, want: 0},
+		{name: "and binds tighter than or right", expr: "n==1 && n==2 || n==3 ? 1 : 0", n: 3, want: 1},
+		{name: "and binds tighter than or right false", expr: "n==1 && n==2 || n==3 ? 1 : 0", n: 1, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr, err := Compile(tt.expr)
+			if err != nil {
+				t.Fatalf("Compile(%q) failed: %v", tt.expr, err)
+			}
+			if got := expr.Eval(tt.n); got != tt.want {
+				t.Errorf("Eval(%q, %d) = %d, want %d", tt.expr, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompile_ReversedRelationalAndUint32Boundaries(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+		n    uint32
+		want int
+	}{
+		{name: "reversed greater", expr: "1 > n", n: 0, want: 1},
+		{name: "reversed greater false", expr: "1 > n", n: 1, want: 0},
+		{name: "reversed greater equal", expr: "1 >= n", n: 1, want: 1},
+		{name: "reversed less", expr: "1 < n", n: 2, want: 1},
+		{name: "reversed less false", expr: "1 < n", n: 1, want: 0},
+		{name: "reversed less equal", expr: "1 <= n", n: 1, want: 1},
+		{name: "maximum equality", expr: "n == 4294967295", n: ^uint32(0), want: 1},
+		{name: "maximum modulo", expr: "n % 4294967295 == 0", n: ^uint32(0), want: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr, err := Compile(tt.expr)
+			if err != nil {
+				t.Fatalf("Compile(%q) failed: %v", tt.expr, err)
+			}
+			if got := expr.Eval(tt.n); got != tt.want {
+				t.Errorf("Eval(%q, %d) = %d, want %d", tt.expr, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompile_ResultLiteralIntRange(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	maxIntLiteral := strconv.FormatInt(int64(maxInt), 10)
+	expr, err := Compile("n==1?" + maxIntLiteral + ":0")
+	if err != nil {
+		t.Fatalf("Compile(max-int result literal) failed: %v", err)
+	}
+	if expr == nil {
+		t.Fatal("Compile(max-int result literal) returned a nil expression")
+	}
+	if got := expr.Eval(1); got != maxInt {
+		t.Errorf("Eval(max-int result literal, 1) = %d, want %d", got, maxInt)
+	}
+
+	overflowLiteral := strconv.FormatUint(uint64(maxInt)+1, 10)
+	expr, err = Compile("n==1?" + overflowLiteral + ":0")
+	if err == nil {
+		t.Error("Compile(result literal above max int) returned no error")
+	}
+	if expr != nil {
+		t.Error("Compile(result literal above max int) returned a non-nil expression")
+	}
+}
+
+func TestCompile_DeeplyNestedParentheses(t *testing.T) {
+	const depth = 32 * 1024
+	input := strings.Repeat("(", depth) + "n==1" + strings.Repeat(")", depth)
+
+	expr, err := Compile(input)
+	if err != nil {
+		t.Fatalf("Compile(%d nested parentheses) failed: %v", depth, err)
+	}
+	if expr == nil {
+		t.Fatalf("Compile(%d nested parentheses) returned a nil expression", depth)
+	}
+	if got := expr.Eval(1); got != 1 {
+		t.Errorf("Eval(%d nested parentheses, 1) = %d, want 1", depth, got)
+	}
+	if got := expr.Eval(2); got != 0 {
+		t.Errorf("Eval(%d nested parentheses, 2) = %d, want 0", depth, got)
+	}
+}
+
+func TestCompile_MalformedExpressionsReturnNil(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	overflowLiteral := strconv.FormatUint(uint64(maxInt)+1, 10)
+	expressions := []string{
+		"",
+		"?1:0",
+		"n==1?:0",
+		"n==1?0:",
+		"n==1?",
+		"n==1:0",
+		"n==1??0:1",
+		"n==1?0::1",
+		"n==1?0:1:2",
+		"n==1&&",
+		"n==1||",
+		"n==1&&&&n==2",
+		"n==1||||n==2",
+		"n==1&&||n==2",
+		"n+@",
+		"n&1",
+		"n|1",
+		"n==1)",
+		"(n==1",
+		"((n==1)",
+		"n==4294967296",
+		"n%4294967296==0",
+		"n==1?" + overflowLiteral + ":0",
+	}
+	for _, input := range expressions {
+		t.Run(fmt.Sprintf("malformed_%q", input), func(t *testing.T) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					t.Fatalf("Compile(%q) panicked: %v", input, recovered)
+				}
+			}()
+			expr, err := Compile(input)
+			if err == nil {
+				t.Fatalf("Compile(%q) returned no error", input)
+			}
+			if expr != nil {
+				t.Fatalf("Compile(%q) returned non-nil expression on error", input)
+			}
+		})
+	}
+}
+
+type panickingTest struct{}
+
+func (panickingTest) test(uint32) bool {
+	panic("inactive test evaluated")
+}
+
+type panickingExpression struct{}
+
+func (panickingExpression) Eval(uint32) int {
+	panic("inactive expression evaluated")
+}
+
+func TestPluralShortCircuiting(t *testing.T) {
+	if got := (and{left: equal{value: 0}, right: panickingTest{}}).test(1); got {
+		t.Error("and evaluated an inactive right-hand test")
+	}
+	if got := (or{left: equal{value: 1}, right: panickingTest{}}).test(1); !got {
+		t.Error("or did not preserve a true left-hand test")
+	}
+	if got := (ternary{
+		test:      equal{value: 0},
+		trueExpr:  panickingExpression{},
+		falseExpr: constValue{value: 2},
+	}).Eval(1); got != 2 {
+		t.Errorf("ternary selected %d, want 2", got)
+	}
+	if got := (ternary{
+		test:      equal{value: 1},
+		trueExpr:  constValue{value: 3},
+		falseExpr: panickingExpression{},
+	}).Eval(1); got != 3 {
+		t.Errorf("ternary selected %d, want 3", got)
+	}
+}
+
+func TestPluralZeroValues(t *testing.T) {
+	if got := (ternary{}).Eval(0); got != -1 {
+		t.Errorf("zero ternary Eval() = %d, want -1", got)
+	}
+	if got := (and{}).test(0); got {
+		t.Error("zero and test returned true")
+	}
+	if got := (or{}).test(0); got {
+		t.Error("zero or test returned true")
+	}
+	if got := (pipe{}).test(0); got {
+		t.Error("zero pipe test returned true")
+	}
+	if got := (mod{}).calc(7); got != 0 {
+		t.Errorf("zero mod calc() = %d, want 0", got)
+	}
+}
+
+func FuzzCompileEvalNoPanic(f *testing.F) {
+	for _, seed := range []string{
+		"0",
+		" n == 1 ? 0 : 1 ",
+		"(n==1)||(n==2)",
+		"n==1?n==2?1:n==3?2:3:4",
+		"n%4294967295==0",
+		"",
+		"n==1&&",
+		"(n==1",
+		"n==4294967296",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		if len(input) > 64<<10 {
+			return
+		}
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				t.Fatalf("Compile(%q) panicked: %v", input, recovered)
+			}
+		}()
+		expr, err := Compile(input)
+		if err != nil {
+			if expr != nil {
+				t.Fatalf("Compile(%q) returned non-nil expression on error", input)
+			}
+			return
+		}
+		if expr == nil {
+			t.Fatalf("Compile(%q) returned a nil expression without an error", input)
+		}
+		for _, n := range []uint32{0, 1, 2, ^uint32(0)} {
+			_ = expr.Eval(n)
+		}
+	})
+}
+
+func FuzzModuloComparisonMatchesUint32(f *testing.F) {
+	for _, seed := range [][3]uint32{
+		{0, 1, 0},
+		{1, 2, 1},
+		{^uint32(0), ^uint32(0), 0},
+		{^uint32(0), 3, 2},
+	} {
+		f.Add(seed[0], seed[1], seed[2])
+	}
+
+	f.Fuzz(func(t *testing.T, n, divisor, value uint32) {
+		if divisor == 0 {
+			return
+		}
+		source := fmt.Sprintf("n%%%d==%d", divisor, value)
+		expr, err := Compile(source)
+		if err != nil {
+			t.Fatalf("Compile(%q) failed: %v", source, err)
+		}
+		want := 0
+		if n%divisor == value {
+			want = 1
+		}
+		if got := expr.Eval(n); got != want {
+			t.Errorf("Eval(%q, %d) = %d, want %d", source, n, got, want)
+		}
+	})
 }

--- a/plurals/expression.go
+++ b/plurals/expression.go
@@ -31,6 +31,9 @@ type ternary struct {
 }
 
 func (t ternary) Eval(n uint32) int {
+	if t.test == nil {
+		return -1
+	}
 	if t.test.test(n) {
 		if t.trueExpr == nil {
 			return -1

--- a/plurals/math.go
+++ b/plurals/math.go
@@ -15,5 +15,8 @@ type mod struct {
 }
 
 func (m mod) calc(n uint32) uint32 {
+	if m.value == 0 {
+		return 0
+	}
 	return n % m.value
 }

--- a/plurals/tests.go
+++ b/plurals/tests.go
@@ -77,6 +77,9 @@ type and struct {
 }
 
 func (e and) test(n uint32) bool {
+	if e.left == nil || e.right == nil {
+		return false
+	}
 	if !e.left.test(n) {
 		return false
 	}
@@ -89,6 +92,9 @@ type or struct {
 }
 
 func (e or) test(n uint32) bool {
+	if e.left == nil || e.right == nil {
+		return false
+	}
 	if e.left.test(n) {
 		return true
 	}
@@ -101,5 +107,8 @@ type pipe struct {
 }
 
 func (e pipe) test(n uint32) bool {
+	if e.modifier == nil || e.action == nil {
+		return false
+	}
 	return e.action.test(e.modifier.calc(n))
 }

--- a/po.go
+++ b/po.go
@@ -52,6 +52,7 @@ const (
 	msgID
 	msgIDPlural
 	msgStr
+	msgStrInvalid
 )
 
 // NewPo should always be used to instantiate a new Po object
@@ -94,7 +95,7 @@ func (po *Po) GetRefs(str string) []string {
 
 // SetPluralResolver sets the plural resolver function
 func (po *Po) SetPluralResolver(f func(int) int) {
-	po.domain.customPluralResolver = f
+	po.domain.SetPluralResolver(f)
 }
 
 // Set translation
@@ -215,7 +216,6 @@ func (po *Po) Parse(buf []byte) {
 	defer po.domain.pluralMutex.Unlock()
 
 	// Get lines
-	lines := strings.Split(string(buf), "\n")
 
 	// Init buffer
 	po.domain.trBuffer = NewTranslation()
@@ -223,7 +223,8 @@ func (po *Po) Parse(buf []byte) {
 	po.domain.refBuffer = ""
 
 	state := head
-	for _, l := range lines {
+	activeMsgStrIndex := 0
+	for l := range strings.Lines(string(buf)) {
 		// Trim spaces
 		l = strings.TrimSpace(l)
 
@@ -257,14 +258,20 @@ func (po *Po) Parse(buf []byte) {
 
 		// Save Translation
 		if strings.HasPrefix(l, "msgstr") {
-			po.parseMessage(l)
-			state = msgStr
+			var ok bool
+			activeMsgStrIndex, ok = po.parseMessage(l)
+			if ok {
+				state = msgStr
+			} else {
+				activeMsgStrIndex = 0
+				state = msgStrInvalid
+			}
 			continue
 		}
 
 		// Multi line strings and headers
 		if strings.HasPrefix(l, "\"") && strings.HasSuffix(l, "\"") {
-			po.parseString(l, state)
+			po.parseString(l, state, activeMsgStrIndex)
 			continue
 		}
 	}
@@ -352,7 +359,7 @@ func (po *Po) parsePluralID(l string) {
 }
 
 // parseMessage takes a line starting with "msgstr" and saves it into the current buffer.
-func (po *Po) parseMessage(l string) {
+func (po *Po) parseMessage(l string) (int, bool) {
 	l = strings.TrimSpace(strings.TrimPrefix(l, "msgstr"))
 
 	// Check for indexed Translation forms
@@ -360,36 +367,44 @@ func (po *Po) parseMessage(l string) {
 		idx := strings.Index(l, "]")
 		if idx == -1 {
 			// Skip wrong index formatting
-			return
+			return 0, false
 		}
 
 		// Parse index
 		i, err := strconv.Atoi(l[1:idx])
 		if err != nil {
 			// Skip wrong index formatting
-			return
+			return 0, false
 		}
 
 		// Parse Translation string
-		po.domain.trBuffer.Trs[i], _ = strconv.Unquote(strings.TrimSpace(l[idx+1:]))
+		clean, err := strconv.Unquote(strings.TrimSpace(l[idx+1:]))
+		if err != nil {
+			return 0, false
+		}
+		po.domain.trBuffer.Trs[i] = clean
 
-		// Loop
-		return
+		return i, true
 	}
 
 	// Save single Translation form under 0 index
-	po.domain.trBuffer.Trs[0], _ = strconv.Unquote(l)
+	clean, err := strconv.Unquote(l)
+	if err != nil {
+		return 0, false
+	}
+	po.domain.trBuffer.Trs[0] = clean
+	return 0, true
 }
 
 // parseString takes a well formatted string without prefix
 // and creates headers or attach multi-line strings when corresponding
-func (po *Po) parseString(l string, state parseState) {
+func (po *Po) parseString(l string, state parseState, activeMsgStrIndex int) {
 	clean, _ := strconv.Unquote(l)
 
 	switch state {
 	case msgStr:
-		// Append to last Translation found
-		po.domain.trBuffer.Trs[len(po.domain.trBuffer.Trs)-1] += clean
+		// Append to active Translation form
+		po.domain.trBuffer.Trs[activeMsgStrIndex] += clean
 
 	case msgID:
 		// Multiline msgid - Append to current id

--- a/po.go
+++ b/po.go
@@ -42,6 +42,9 @@ type Po struct {
 
 	domain *Domain
 	fs     fs.FS
+
+	parseBufferHasID     bool
+	parseBufferHasPlural bool
 }
 
 type parseState int
@@ -215,12 +218,12 @@ func (po *Po) Parse(buf []byte) {
 	defer po.domain.trMutex.Unlock()
 	defer po.domain.pluralMutex.Unlock()
 
-	// Get lines
-
 	// Init buffer
 	po.domain.trBuffer = NewTranslation()
 	po.domain.ctxBuffer = ""
 	po.domain.refBuffer = ""
+	po.parseBufferHasID = false
+	po.parseBufferHasPlural = false
 
 	state := head
 	activeMsgStrIndex := 0
@@ -234,30 +237,52 @@ func (po *Po) Parse(buf []byte) {
 			continue
 		}
 
-		// Buffer context and continue
-		if strings.HasPrefix(l, "msgctxt") {
-			po.parseContext(l)
-			state = msgCtxt
+		// Multi line strings and headers
+		if strings.HasPrefix(l, "\"") {
+			if !po.parseString(l, state, activeMsgStrIndex) && state != head {
+				state = msgStrInvalid
+			}
 			continue
 		}
 
-		// Buffer msgid and continue
-		if strings.HasPrefix(l, "msgid") && !strings.HasPrefix(l, "msgid_plural") {
-			po.parseID(l)
-			state = msgID
+		// Buffer context and continue
+		if po.hasKeywordBoundary(l, "msgctxt") {
+			if po.parseContext(l) {
+				state = msgCtxt
+			} else {
+				state = msgStrInvalid
+			}
 			continue
 		}
 
 		// Check for plural form
-		if strings.HasPrefix(l, "msgid_plural") {
-			po.parsePluralID(l)
-			po.domain.pluralTranslations[po.domain.trBuffer.PluralID] = po.domain.trBuffer
-			state = msgIDPlural
+		if po.hasKeywordBoundary(l, "msgid_plural") {
+			if state != msgID || !po.parsePluralID(l) {
+				state = msgStrInvalid
+			} else {
+				state = msgIDPlural
+			}
+			continue
+		}
+
+		// Buffer msgid and continue
+		if po.hasKeywordBoundary(l, "msgid") {
+			if po.parseID(l) {
+				state = msgID
+			} else {
+				state = msgStrInvalid
+			}
 			continue
 		}
 
 		// Save Translation
-		if strings.HasPrefix(l, "msgstr") {
+		if po.hasKeywordBoundary(l, "msgstr") {
+			if state != msgID && state != msgIDPlural && state != msgStr {
+				activeMsgStrIndex = 0
+				state = msgStrInvalid
+				continue
+			}
+
 			var ok bool
 			activeMsgStrIndex, ok = po.parseMessage(l)
 			if ok {
@@ -268,16 +293,15 @@ func (po *Po) Parse(buf []byte) {
 			}
 			continue
 		}
-
-		// Multi line strings and headers
-		if strings.HasPrefix(l, "\"") && strings.HasSuffix(l, "\"") {
-			po.parseString(l, state, activeMsgStrIndex)
-			continue
-		}
 	}
 
-	// Save last Translation buffer.
-	po.saveBuffer()
+	// Save last Translation buffer, but do not synthesize an entry after an
+	// invalid directive. Preserve the historical empty-input entry.
+	if po.parseBufferHasID {
+		po.saveBuffer()
+	} else if len(buf) == 0 {
+		po.domain.translations[""] = po.domain.trBuffer
+	}
 
 	// Parse headers
 	po.domain.parseHeaders()
@@ -292,6 +316,16 @@ func (po *Po) Parse(buf []byte) {
 // saveBuffer takes the context and Translation buffers
 // and saves it on the translations collection
 func (po *Po) saveBuffer() {
+	if !po.parseBufferHasID {
+		return
+	}
+
+	// Store a completed plural ID after all of its continuation lines have
+	// been decoded.
+	if po.parseBufferHasPlural {
+		po.domain.pluralTranslations[po.domain.trBuffer.PluralID] = po.domain.trBuffer
+	}
+
 	// With no context...
 	if po.domain.ctxBuffer == "" {
 		po.domain.translations[po.domain.trBuffer.ID] = po.domain.trBuffer
@@ -308,6 +342,8 @@ func (po *Po) saveBuffer() {
 		}
 	}
 
+	po.parseBufferHasID = false
+	po.parseBufferHasPlural = false
 	// Flush Translation buffer
 	if po.domain.refBuffer == "" {
 		po.domain.trBuffer = NewTranslation()
@@ -335,37 +371,59 @@ func (po *Po) parseComment(l string, state parseState) {
 
 // parseContext takes a line starting with "msgctxt",
 // saves the current Translation buffer and creates a new context.
-func (po *Po) parseContext(l string) {
+func (po *Po) parseContext(l string) bool {
+	value, ok := po.parseQuotedDirective(l, "msgctxt")
+	if !ok {
+		return false
+	}
+
 	// Save current Translation buffer.
 	po.saveBuffer()
 
 	// Buffer context
-	po.domain.ctxBuffer, _ = strconv.Unquote(strings.TrimSpace(strings.TrimPrefix(l, "msgctxt")))
+	po.domain.ctxBuffer = value
+	return true
 }
 
 // parseID takes a line starting with "msgid",
 // saves the current Translation and creates a new msgid buffer.
-func (po *Po) parseID(l string) {
+func (po *Po) parseID(l string) bool {
+	value, ok := po.parseQuotedDirective(l, "msgid")
+	if !ok {
+		return false
+	}
+
 	// Save current Translation buffer.
 	po.saveBuffer()
 
 	// Set id
-	po.domain.trBuffer.ID, _ = strconv.Unquote(strings.TrimSpace(strings.TrimPrefix(l, "msgid")))
+	po.domain.trBuffer.ID = value
+	po.parseBufferHasID = true
+	return true
 }
 
 // parsePluralID saves the plural id buffer from a line starting with "msgid_plural"
-func (po *Po) parsePluralID(l string) {
-	po.domain.trBuffer.PluralID, _ = strconv.Unquote(strings.TrimSpace(strings.TrimPrefix(l, "msgid_plural")))
+func (po *Po) parsePluralID(l string) bool {
+	value, ok := po.parseQuotedDirective(l, "msgid_plural")
+	if !ok {
+		return false
+	}
+
+	po.domain.trBuffer.PluralID = value
+	po.parseBufferHasPlural = true
+	return true
 }
 
 // parseMessage takes a line starting with "msgstr" and saves it into the current buffer.
 func (po *Po) parseMessage(l string) (int, bool) {
-	l = strings.TrimSpace(strings.TrimPrefix(l, "msgstr"))
-
+	if !po.hasKeywordBoundary(l, "msgstr") {
+		return 0, false
+	}
+	l = strings.TrimSpace(l[len("msgstr"):])
 	// Check for indexed Translation forms
 	if strings.HasPrefix(l, "[") {
-		idx := strings.Index(l, "]")
-		if idx == -1 {
+		idx := strings.IndexByte(l, ']')
+		if idx <= 1 || !isASCIIPluralIndex(l[1:idx]) {
 			// Skip wrong index formatting
 			return 0, false
 		}
@@ -398,8 +456,15 @@ func (po *Po) parseMessage(l string) (int, bool) {
 
 // parseString takes a well formatted string without prefix
 // and creates headers or attach multi-line strings when corresponding
-func (po *Po) parseString(l string, state parseState, activeMsgStrIndex int) {
-	clean, _ := strconv.Unquote(l)
+func (po *Po) parseString(l string, state parseState, activeMsgStrIndex int) bool {
+	if state == msgStrInvalid {
+		return false
+	}
+
+	clean, err := strconv.Unquote(l)
+	if err != nil {
+		return false
+	}
 
 	switch state {
 	case msgStr:
@@ -417,26 +482,65 @@ func (po *Po) parseString(l string, state parseState, activeMsgStrIndex int) {
 	case msgCtxt:
 		// Multiline context - Append to current context
 		po.domain.ctxBuffer += clean
-
 	}
+
+	return true
 }
 
-// isValidLine checks for line prefixes to detect valid syntax.
 func (po *Po) isValidLine(l string) bool {
-	// Check prefix
-	valid := []string{
-		"\"",
-		"msgctxt",
-		"msgid",
-		"msgid_plural",
-		"msgstr",
+	if strings.HasPrefix(l, "\"") {
+		return true
 	}
 
-	for _, v := range valid {
-		if strings.HasPrefix(l, v) {
+	for _, keyword := range []string{
+		"msgctxt",
+		"msgid_plural",
+		"msgid",
+		"msgstr",
+	} {
+		if po.hasKeywordBoundary(l, keyword) {
 			return true
 		}
 	}
 
 	return false
+}
+
+func (po *Po) hasKeywordBoundary(l, keyword string) bool {
+	if !strings.HasPrefix(l, keyword) {
+		return false
+	}
+	if len(l) == len(keyword) {
+		return true
+	}
+
+	next := l[len(keyword)]
+	if keyword == "msgstr" && next == '[' {
+		return true
+	}
+	return next == ' ' || next == '\t'
+}
+
+func (po *Po) parseQuotedDirective(l, keyword string) (string, bool) {
+	if !po.hasKeywordBoundary(l, keyword) {
+		return "", false
+	}
+
+	value, err := strconv.Unquote(strings.TrimSpace(l[len(keyword):]))
+	if err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func isASCIIPluralIndex(index string) bool {
+	if index == "" {
+		return false
+	}
+	for i := 0; i < len(index); i++ {
+		if index[i] < '0' || index[i] > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/po_test.go
+++ b/po_test.go
@@ -882,3 +882,185 @@ func TestPoParseSparsePluralContinuation(t *testing.T) {
 		t.Fatalf("plural forms = %v, want only index 2", translation.Trs)
 	}
 }
+
+func TestPoParseRejectsMalformedPluralIndexes(t *testing.T) {
+	tests := []string{
+		"",
+		"-1",
+		"+1",
+		" 1",
+		"1x",
+		"١",
+		"18446744073709551616",
+	}
+
+	for _, index := range tests {
+		t.Run(fmt.Sprintf("index_%q", index), func(t *testing.T) {
+			po := NewPo()
+			po.Parse([]byte("msgid \"id\"\nmsgstr[" + index + "] \"form\"\n\"tail\"\n"))
+
+			translation, ok := po.GetDomain().translations["id"]
+			if !ok {
+				t.Fatal("expected untranslated entry for msgid")
+			}
+			if len(translation.Trs) != 0 {
+				t.Fatalf("malformed plural index created forms: %v", translation.Trs)
+			}
+			for form := range translation.Trs {
+				if form < 0 {
+					t.Fatalf("malformed plural index created negative form %d", form)
+				}
+			}
+		})
+	}
+}
+
+func TestPoParseRejectsInvalidDirectivesWithoutMutation(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "msgid",
+			input: "msgid \"unterminated\n\"tail\"\nmsgstr \"ignored\"\n",
+		},
+		{
+			name:  "msgctxt",
+			input: "msgctxt \"unterminated\n\"tail\"\n",
+		},
+		{
+			name:  "msgid_plural",
+			input: "msgid \"id\"\nmsgid_plural \"unterminated\n\"tail\"\nmsgstr[0] \"ignored\"\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			po := NewPo()
+			po.Set("sentinel", "preserved")
+			po.Parse([]byte(test.input))
+
+			if got := po.Get("sentinel"); got != "preserved" {
+				t.Fatalf("sentinel translation = %q, want %q", got, "preserved")
+			}
+			if _, ok := po.GetDomain().translations["tail"]; ok {
+				t.Fatal("invalid directive continuation created an entry")
+			}
+			if test.name == "msgid_plural" {
+				translation, ok := po.GetDomain().translations["id"]
+				if !ok {
+					t.Fatal("expected valid msgid to remain untranslated")
+				}
+				if len(translation.Trs) != 0 {
+					t.Fatalf("invalid plural directive created forms: %v", translation.Trs)
+				}
+				if len(po.GetDomain().pluralTranslations) != 0 {
+					t.Fatalf("plural translations = %v, want none", po.GetDomain().pluralTranslations)
+				}
+			}
+			wantTranslations := 1
+			if test.name == "msgid_plural" {
+				wantTranslations = 2
+			}
+			if len(po.GetDomain().translations) != wantTranslations {
+				t.Fatalf("translations = %v, want %d entries", po.GetDomain().translations, wantTranslations)
+			}
+		})
+	}
+}
+
+func TestPoParseRequiresDirectiveKeywordBoundaries(t *testing.T) {
+	for _, keyword := range []string{"msgctxt", "msgid", "msgid_plural", "msgstr"} {
+		t.Run(keyword, func(t *testing.T) {
+			po := NewPo()
+			po.Set("sentinel", "preserved")
+			po.Parse([]byte(keyword + "suffix \"value\"\n\"tail\"\n"))
+
+			if got := po.Get("sentinel"); got != "preserved" {
+				t.Fatalf("sentinel translation = %q, want %q", got, "preserved")
+			}
+			if len(po.GetDomain().translations) != 1 {
+				t.Fatalf("translations = %v, want only the sentinel", po.GetDomain().translations)
+			}
+		})
+	}
+}
+
+func TestPoParseEscapedMultilineContextIDPluralAndForms(t *testing.T) {
+	po := NewPo()
+	po.Parse([]byte(`msgctxt "ctx\"\\\n\x00"
+"tail"
+msgid "id\"\\\n\x00"
+"tail"
+msgid_plural "plural\"\\\n\x00"
+"tail"
+msgstr[0] "one\"\\\n\x00"
+"tail"
+msgstr[1] "two"
+`))
+
+	context := "ctx\"\\\n\x00tail"
+	id := "id\"\\\n\x00tail"
+	plural := "plural\"\\\n\x00tail"
+	if _, ok := po.GetDomain().pluralTranslations[plural]; !ok {
+		t.Fatal("expected completed plural ID in plural translation map")
+	}
+	translation, ok := po.GetDomain().contextTranslations[context][id]
+	if !ok {
+		t.Fatal("expected escaped context translation")
+	}
+	if got := translation.PluralID; got != plural {
+		t.Fatalf("plural ID = %q, want %q", got, plural)
+	}
+	if got := translation.Trs[0]; got != "one\"\\\n\x00tail" {
+		t.Fatalf("translation form 0 = %q, want %q", got, "one\"\\\n\x00tail")
+	}
+	if got := translation.Trs[1]; got != "two" {
+		t.Fatalf("translation form 1 = %q, want %q", got, "two")
+	}
+}
+
+func FuzzPoParseMalformedInput(f *testing.F) {
+	f.Add([]byte("msgid \"id\"\nmsgstr \"translated\"\n"))
+	f.Add([]byte("msgid \"id\"\nmsgstr[-1] \"bad\"\n\"tail\"\n"))
+	f.Add([]byte("msgid \"unterminated\n\"tail\"\n"))
+	f.Add([]byte("msgid_plural \"plural\"\nmsgstr[+1] \"bad\"\n"))
+	f.Add([]byte("msgstring \"not a directive\"\n\"tail\"\n"))
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		if len(input) > 64<<10 {
+			return
+		}
+
+		po := NewPo()
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				t.Fatalf("Parse panicked: %v", recovered)
+			}
+		}()
+
+		po.Parse(input)
+		for id, translation := range po.GetDomain().translations {
+			if translation == nil {
+				t.Fatalf("translation %q is nil", id)
+			}
+			for form := range translation.Trs {
+				if form < 0 {
+					t.Fatalf("translation %q has negative plural form %d", id, form)
+				}
+			}
+		}
+		for context, translations := range po.GetDomain().contextTranslations {
+			for id, translation := range translations {
+				if translation == nil {
+					t.Fatalf("context translation %q/%q is nil", context, id)
+				}
+				for form := range translation.Trs {
+					if form < 0 {
+						t.Fatalf("context translation %q/%q has negative plural form %d", context, id, form)
+					}
+				}
+			}
+		}
+	})
+}

--- a/po_test.go
+++ b/po_test.go
@@ -368,7 +368,6 @@ type pluralTest struct {
 func pluralExpected(t *testing.T, pluralTests []pluralTest, domain *Domain) {
 	t.Helper()
 	for _, pt := range pluralTests {
-		pt := pt
 		t.Run(fmt.Sprintf("pluralForm(%d)", pt.num), func(t *testing.T) {
 			n := domain.pluralForm(pt.num)
 			if n != pt.form {
@@ -795,5 +794,91 @@ func TestPo_MissingWrappers(t *testing.T) {
 	if po.IsTranslatedNC("missing", 1, "ctx") {
 		t.Error("Po.IsTranslatedNC failed")
 	}
+}
+
+func TestPoParseLinesBoundaries(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		po := NewPo()
+		po.Parse(nil)
+
+		translation, ok := po.GetDomain().translations[""]
+		if !ok {
+			t.Fatal("expected empty translation entry")
+		}
+		if translation == nil {
+			t.Fatal("expected non-nil empty translation")
+		}
+		if len(translation.Trs) != 0 {
+			t.Fatalf("expected no forms for empty input, got %v", translation.Trs)
+		}
+		if po.Headers == nil {
+			t.Fatal("expected initialized headers for empty input")
+		}
+	})
+
+	t.Run("unterminated final msgstr", func(t *testing.T) {
+		po := NewPo()
+		po.Parse([]byte("msgid \"id\"\nmsgstr \"translated\""))
+
+		translation, ok := po.GetDomain().translations["id"]
+		if !ok {
+			t.Fatal("expected translation for unterminated final line")
+		}
+		if got := translation.Trs[0]; got != "translated" {
+			t.Fatalf("translation = %q, want %q", got, "translated")
+		}
+	})
+}
+
+func TestPoParseInvalidMessageContinuations(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "invalid index",
+			input: "msgid \"x\"\nmsgstr[bad]\n\"tail\"\n",
+		},
+		{
+			name:  "invalid payload",
+			input: "msgid \"x\"\nmsgstr[2] \"unterminated\n\"tail\"\n",
+		},
 	}
 
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			po := NewPo()
+			po.Parse([]byte(test.input))
+
+			translation, ok := po.GetDomain().translations["x"]
+			if !ok {
+				t.Fatal("expected untranslated entry for msgid")
+			}
+			if len(translation.Trs) != 0 {
+				t.Fatalf("invalid msgstr created forms: %v", translation.Trs)
+			}
+			if _, ok := po.GetDomain().translations["xtail"]; ok {
+				t.Fatal("invalid msgstr continuation modified the msgid")
+			}
+		})
+	}
+}
+
+func TestPoParseSparsePluralContinuation(t *testing.T) {
+	po := NewPo()
+	po.Parse([]byte("msgid \"x\"\nmsgstr[2] \"two\"\n\" tail\"\n"))
+
+	translation, ok := po.GetDomain().translations["x"]
+	if !ok {
+		t.Fatal("expected plural translation")
+	}
+	if got := translation.Trs[2]; got != "two tail" {
+		t.Fatalf("plural form 2 = %q, want %q", got, "two tail")
+	}
+	if _, ok := translation.Trs[0]; ok {
+		t.Fatal("unexpected synthetic plural form 0")
+	}
+	if len(translation.Trs) != 1 {
+		t.Fatalf("plural forms = %v, want only index 2", translation.Trs)
+	}
+}

--- a/po_test.go
+++ b/po_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"reflect"
+	"strconv"
 	"testing"
 )
 
@@ -1060,6 +1062,42 @@ func FuzzPoParseMalformedInput(f *testing.F) {
 					}
 				}
 			}
+		}
+	})
+}
+
+func FuzzPoRejectedRecordDoesNotMutate(f *testing.F) {
+	f.Add([]byte("rejected record"))
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		if len(input) > 64<<10 {
+			return
+		}
+
+		po := NewPo()
+		po.Set("ordinary id", "ordinary translation")
+		po.SetC("contextual id", "context", "contextual translation")
+
+		wantTranslations := po.GetDomain().GetTranslations()
+		wantContextTranslations := po.GetDomain().GetCtxTranslations()
+
+		quoted := strconv.Quote(string(input))
+		record := []byte("msgid " + quoted[:len(quoted)-1])
+
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				t.Fatalf("Parse panicked: %v", recovered)
+			}
+		}()
+
+		po.Parse(record)
+
+		if got := po.GetDomain().GetTranslations(); !reflect.DeepEqual(got, wantTranslations) {
+			t.Fatalf("ordinary translations changed: got %#v, want %#v", got, wantTranslations)
+		}
+		if got := po.GetDomain().GetCtxTranslations(); !reflect.DeepEqual(got, wantContextTranslations) {
+			t.Fatalf("context translations changed: got %#v, want %#v", got, wantContextTranslations)
 		}
 	})
 }

--- a/po_test.go
+++ b/po_test.go
@@ -748,9 +748,8 @@ func TestPoTextEncoding(t *testing.T) {
 	}
 }
 
-func TestPo_MissingWrappers(t *testing.T) {
+func TestPoWrapperBehavior(t *testing.T) {
 	po := NewPo()
-	// Coverage for SetRefs, GetRefs, SetPluralResolver, etc in Po
 	po.SetRefs("id", []string{"ref"})
 	refs := po.GetRefs("id")
 	if len(refs) != 1 || refs[0] != "ref" {

--- a/translator.go
+++ b/translator.go
@@ -65,6 +65,9 @@ type TranslatorEncoding struct {
 // deserialize into a Po-compatible object.
 func (te *TranslatorEncoding) GetTranslator() Translator {
 	po := NewPo()
+	if te == nil {
+		return po
+	}
 
 	headers := te.Headers
 	if headers == nil {
@@ -74,9 +77,29 @@ func (te *TranslatorEncoding) GetTranslator() Translator {
 	if translations == nil {
 		translations = make(map[string]*Translation)
 	}
+	for id, translation := range translations {
+		if translation == nil {
+			translation = NewTranslation()
+			translation.ID = id
+			translations[id] = translation
+		}
+	}
 	contexts := te.Contexts
 	if contexts == nil {
 		contexts = make(map[string]map[string]*Translation)
+	}
+	for context, translationsForContext := range contexts {
+		if translationsForContext == nil {
+			contexts[context] = make(map[string]*Translation)
+			continue
+		}
+		for id, translation := range translationsForContext {
+			if translation == nil {
+				translation = NewTranslation()
+				translation.ID = id
+				translationsForContext[id] = translation
+			}
+		}
 	}
 
 	po.domain.Headers = headers

--- a/translator.go
+++ b/translator.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+
+	"github.com/leonelquinteros/gotext/plurals"
 )
 
 // Translator interface is used by Locale and Po objects.Translator
@@ -63,14 +65,35 @@ type TranslatorEncoding struct {
 // deserialize into a Po-compatible object.
 func (te *TranslatorEncoding) GetTranslator() Translator {
 	po := NewPo()
-	po.domain = NewDomain()
-	po.domain.Headers = te.Headers
+
+	headers := te.Headers
+	if headers == nil {
+		headers = make(HeaderMap)
+	}
+	translations := te.Translations
+	if translations == nil {
+		translations = make(map[string]*Translation)
+	}
+	contexts := te.Contexts
+	if contexts == nil {
+		contexts = make(map[string]map[string]*Translation)
+	}
+
+	po.domain.Headers = headers
 	po.domain.Language = te.Language
 	po.domain.PluralForms = te.PluralForms
 	po.domain.nplurals = te.Nplurals
 	po.domain.plural = te.Plural
-	po.domain.translations = te.Translations
-	po.domain.contextTranslations = te.Contexts
+	po.domain.translations = translations
+	po.domain.contextTranslations = contexts
+
+	if expr, err := plurals.Compile(te.Plural); err == nil {
+		po.domain.pluralforms = expr
+	}
+
+	po.Headers = po.domain.Headers
+	po.Language = po.domain.Language
+	po.PluralForms = po.domain.PluralForms
 
 	return po
 }


### PR DESCRIPTION
## Is this a fix, improvement or something else?

Mostly a maintenance update. It moves the project to Go 1.27 and includes fixes for issues found while testing the upgrade.

## What does this change implement/fix?

The module and GitHub workflows now use Go 1.27, and `golang.org/x/tools` is updated to a version that supports it. Older loops and helpers were replaced where the standard library now provides a clearer equivalent.

The additional tests found a few existing problems: empty locale storage could panic, translator callbacks could run while locale locks were held, malformed catalogs could leave partial state behind, big-endian MO files were not decoded correctly, and some plural and xgotext expressions were handled incorrectly. Those cases are fixed and covered by regression and fuzz tests.

Rejected PO, MO, Domain, and Locale inputs are also fuzzed against preexisting state. The tests verify that rejected input does not panic or change translations, configuration, or domain membership. MO fuzzing separately verifies the parser's accepted shared-payload layout without changing production overlap semantics.

## Validation

- `go test -race -count=1 ./...`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.0 run`
- `go build -mod=readonly ./...`
- all twelve fuzz targets passed with bounded runs

## I have ...

- [x] answered the 2 questions above,
- [ ] discussed this change in an issue,
- [x] included tests to cover these changes.
